### PR TITLE
feat: add workspace structure and setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,30 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This workspace contains all Open Service Portal repositories for unified Backstage development.
 
+```
+portal-workspace/            # Workspace root and shared context
+├── CLAUDE.md               # Project context (this file)
+├── README.md               # Project overview
+├── docs/                   # Documentation
+├── concepts/               # Concepts documentation
+└── app-portal/             # Code repository
+```
+
+## Setup
+
+To set up the complete workspace, clone all repositories:
+
+```bash
+# Clone the workspace
+git clone https://github.com/open-service-portal/portal-workspace.git
+
+# Navigate to the workspace
+cd portal-workspace
+
+# Clone the app-portal code repository inside the workspace
+git clone https://github.com/open-service-portal/app-portal.git
+```
+
 ### GitHub Organization
 
 - **open-service-portal** - Organization for the Open Service Portal project


### PR DESCRIPTION
## Summary
- Added visual workspace structure diagram showing portal-workspace as the root directory
- Added setup section with step-by-step clone instructions for the workspace and app-portal repository
- Clarified that app-portal is a code repository that lives inside the workspace directory

## Changes
- Updated `CLAUDE.md` to include:
  - Workspace structure diagram starting with `portal-workspace/` as root
  - Setup instructions for cloning both the workspace and app-portal repos
  - Clear indication that app-portal is cloned inside the workspace

## Test plan
- [x] Verify the workspace structure matches the actual directory layout
- [x] Test the setup instructions by following them in a clean directory
- [x] Confirm the documentation is clear and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)