### PR TITLE
docs: add zero-config frontend development documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,27 @@ git clone https://github.com/open-service-portal/app-portal.git
 
 ## Development
 
+### Quick Start Options
+
+#### Zero-Config Frontend Development (NEW!)
+```bash
+cd app-portal
+yarn install
+yarn dev  # No configuration needed!
+```
+
+The `yarn dev` command starts Backstage with:
+- Guest authentication (no GitHub tokens required)
+- Mock data from examples/ directory
+- In-memory SQLite database
+- No external integrations
+- Perfect for UI/theme development
+
+#### Full Development Setup
+Requires environment configuration with GitHub tokens. See app-portal documentation for setup.
+
+### Repository-Specific Commands
+
 Each repository has its own `CLAUDE.md` file with specific development commands:
 
 - **app-portal/CLAUDE.md** - Backstage development commands, build instructions, plugin creation

--- a/README.md
+++ b/README.md
@@ -34,10 +34,27 @@ Each repository has its own development workflow. See [CLAUDE.md](./CLAUDE.md) f
 
 ### Quick Start
 
+#### Zero-Config Frontend Development
+
+For immediate frontend development without any configuration:
+
 ```bash
-# Start Backstage
 cd app-portal
 yarn install
+yarn dev  # No tokens or secrets needed!
+```
+
+This starts Backstage with mock data and guest authentication - perfect for UI/theme development.
+
+#### Full Development Setup
+
+For complete functionality with GitHub integration:
+
+```bash
+# Start Backstage with full features
+cd app-portal
+yarn install
+# Configure your .envrc with tokens (see docs/github-app-setup.md)
 yarn start
 ```
 


### PR DESCRIPTION
## Summary
This PR adds documentation for the new zero-config frontend development mode introduced in the app-portal repository.

## Changes
- Updated CLAUDE.md with zero-config development instructions
- Added clear documentation for `yarn dev` command that requires no setup
- Highlighted the difference between zero-config mode and full development setup

## Benefits
- Developers can start working on UI immediately without any configuration
- No need for GitHub tokens or environment setup for frontend work
- Reduces onboarding friction for new contributors

## Related
- Complements the zero-config mode added to app-portal
- Makes it easier for developers to get started with Backstage development