### PR TITLE
feat: add provider-helm and improve manifest organization

### DIFF
--- a/docs/provider-helm-usage.md
+++ b/docs/provider-helm-usage.md
@@ -1,0 +1,155 @@
+# Provider-Helm Usage Guide
+
+## Overview
+Provider-helm enables Crossplane to deploy Helm charts as managed resources. Think of it as the **supplier** that provides pre-packaged ingredients (Helm charts) like Bitnami PostgreSQL, Redis, or any other Helm chart.
+
+## Installation
+Provider-helm is automatically installed by our setup script:
+```bash
+./scripts/setup-cluster.sh
+```
+
+## Basic Usage Pattern
+
+### 1. Create a Release Resource
+```yaml
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: my-postgresql
+spec:
+  forProvider:
+    chart:
+      name: postgresql
+      repository: https://charts.bitnami.com/bitnami
+      version: "13.2.24"
+    namespace: databases
+    values:
+      auth:
+        database: myapp
+        username: myuser
+  providerConfigRef:
+    name: helm-provider
+```
+
+### 2. Use in a Composition
+```yaml
+apiVersion: apiextensions.crossplane.io/v2
+kind: Composition
+metadata:
+  name: database-helm
+spec:
+  compositeTypeRef:
+    apiVersion: platform.io/v1alpha1
+    kind: XDatabase
+  mode: Pipeline
+  pipeline:
+    - step: deploy-postgresql
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.crossplane.io/v1
+        kind: Resources
+        resources:
+          - name: postgresql
+            base:
+              apiVersion: helm.crossplane.io/v1beta1
+              kind: Release
+              spec:
+                forProvider:
+                  chart:
+                    name: postgresql
+                    repository: https://charts.bitnami.com/bitnami
+                  namespace: databases
+                providerConfigRef:
+                  name: helm-provider
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.size
+                toFieldPath: spec.forProvider.values.primary.persistence.size
+```
+
+## Common Helm Charts
+
+### Bitnami PostgreSQL
+```yaml
+chart:
+  name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+```
+
+### Redis
+```yaml
+chart:
+  name: redis
+  repository: https://charts.bitnami.com/bitnami
+```
+
+### NGINX
+```yaml
+chart:
+  name: nginx
+  repository: https://charts.bitnami.com/bitnami
+```
+
+## Testing Provider-Helm
+
+### Simple Test Deployment
+```bash
+# Create a test namespace
+kubectl create namespace helm-test
+
+# Deploy a simple nginx chart
+kubectl apply -f - <<EOF
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: test-nginx
+spec:
+  forProvider:
+    chart:
+      name: nginx
+      repository: https://charts.bitnami.com/bitnami
+      version: "15.14.0"
+    namespace: helm-test
+    values:
+      service:
+        type: ClusterIP
+  providerConfigRef:
+    name: helm-provider
+EOF
+
+# Check the release
+kubectl get releases.helm.crossplane.io
+kubectl get pods -n helm-test
+
+# Clean up
+kubectl delete release test-nginx
+kubectl delete namespace helm-test
+```
+
+## Troubleshooting
+
+### Check Provider Status
+```bash
+kubectl get providers.pkg.crossplane.io provider-helm
+kubectl describe providerconfig.helm.crossplane.io helm-provider
+```
+
+### View Provider Logs
+```bash
+kubectl logs -l pkg.crossplane.io/provider=provider-helm -n crossplane-system
+```
+
+### Common Issues
+
+1. **Release Stuck in Creating**: Check namespace exists and chart values are valid
+2. **Authentication Errors**: Verify ProviderConfig uses correct credentials
+3. **Chart Not Found**: Ensure repository URL is correct and accessible
+
+## Restaurant Analogy
+- **Supplier** = Provider-helm
+- **Pre-packaged Ingredients** = Helm charts (PostgreSQL, Redis, etc.)
+- **Delivery Instructions** = Release resource with values
+- **Kitchen** = Composition that uses the Release
+- **Final Dish** = Deployed application with all dependencies

--- a/scripts/cluster-manifests/MANIFESTS.md
+++ b/scripts/cluster-manifests/MANIFESTS.md
@@ -1,0 +1,78 @@
+# Cluster Manifests Documentation
+
+This directory contains all the manifests installed by `setup-cluster.sh` to configure the Kubernetes cluster for the Open Service Portal.
+
+## Files Overview
+
+### Crossplane Core
+- **`crossplane-provider-kubernetes.yaml`** - Provider for managing Kubernetes resources (ConfigMaps, Services, etc.)
+- **`crossplane-provider-kubernetes-config.yaml`** - Auth configuration for the Kubernetes provider
+- **`crossplane-provider-helm.yaml`** - Provider for deploying Helm charts (PostgreSQL, Redis, etc.)
+- **`crossplane-provider-helm-config.yaml`** - Auth configuration for the Helm provider
+- **`crossplane-functions.yaml`** - Composition pipeline functions for resource transformation
+- **`environment-configs.yaml`** - Platform-wide shared configuration
+
+### GitOps
+- **`flux-catalog.yaml`** - Flux configuration to watch and sync the template catalog
+
+## How Functions Work with Providers
+
+The composition functions (go-templating, patch-and-transform, etc.) are **provider-agnostic**. They work in the pipeline to:
+1. Generate or transform resource specifications
+2. Pass the resources to the appropriate provider
+3. The provider then creates the actual resources
+
+### Example: Using provider-kubernetes with functions
+```yaml
+pipeline:
+  - step: create-service
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |
+          apiVersion: kubernetes.crossplane.io/v1alpha2
+          kind: Object  # This will be handled by provider-kubernetes
+          spec:
+            forProvider:
+              manifest:
+                apiVersion: v1
+                kind: Service
+                # ...
+```
+
+### Example: Using provider-helm with functions
+```yaml
+pipeline:
+  - step: deploy-postgresql
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.crossplane.io/v1
+      kind: Resources
+      resources:
+        - name: postgresql
+          base:
+            apiVersion: helm.crossplane.io/v1beta1
+            kind: Release  # This will be handled by provider-helm
+            spec:
+              forProvider:
+                chart:
+                  name: postgresql
+                  repository: https://charts.bitnami.com/bitnami
+```
+
+## No Additional Functions Needed
+
+The existing functions are sufficient because:
+- **Functions transform data** - They manipulate YAML/JSON specifications
+- **Providers create resources** - They take the specs and create actual resources
+- **They're complementary** - Functions prepare the "recipe", providers do the "cooking"
+
+## Restaurant Analogy
+- **Functions** = Recipe techniques (chopping, mixing, seasoning)
+- **Providers** = Cooking equipment (ovens, grills, fryers)
+- You can use the same techniques with different equipment!

--- a/scripts/cluster-manifests/crossplane-functions.yaml
+++ b/scripts/cluster-manifests/crossplane-functions.yaml
@@ -1,6 +1,13 @@
+# Crossplane Composition Functions
+# Purpose: Pipeline-mode functions for advanced resource composition
+# Restaurant Analogy: The "recipe processors" - transform ingredients using different techniques
+#
+# These functions are installed globally and can be used by any Composition:
+# - go-templating: Generate resources using Go templates (most flexible)
+# - patch-and-transform: Traditional field mapping and transformation
+# - auto-ready: Automatically mark composite resources as ready
+# - environment-configs: Load shared configuration from the platform
 ---
-# Common Crossplane Composition Functions
-# These are installed by default to support advanced compositions
 apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:

--- a/scripts/cluster-manifests/crossplane-provider-helm-config.yaml
+++ b/scripts/cluster-manifests/crossplane-provider-helm-config.yaml
@@ -1,0 +1,15 @@
+# Crossplane ProviderConfig: Helm
+# Purpose: Configures how provider-helm authenticates to deploy Helm charts
+# Auth Method: InjectedIdentity - Uses the provider pod's service account
+#
+# This configuration tells provider-helm to use its own service account
+# to interact with the Kubernetes API when deploying Helm charts.
+# The provider automatically uses in-cluster configuration.
+
+apiVersion: helm.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: helm-provider
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/scripts/cluster-manifests/crossplane-provider-helm.yaml
+++ b/scripts/cluster-manifests/crossplane-provider-helm.yaml
@@ -1,0 +1,15 @@
+# Provider: Helm
+# Purpose: Enables Crossplane to deploy and manage Helm charts as managed resources
+# Restaurant Analogy: The "pre-packaged meal supplier" - provides ready-to-heat dishes
+# Version: v1.0.0 - Latest stable, compatible with Crossplane v2.0
+#
+# This provider allows Compositions to deploy any Helm chart from any repository,
+# perfect for databases (PostgreSQL, Redis), monitoring (Prometheus), and more.
+# Supports Helm 3, OCI registries, and namespace-scoped releases.
+
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-helm
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.0.0

--- a/scripts/cluster-manifests/crossplane-provider-kubernetes-config.yaml
+++ b/scripts/cluster-manifests/crossplane-provider-kubernetes-config.yaml
@@ -1,0 +1,15 @@
+# ProviderConfig: Kubernetes
+# Purpose: Configures how provider-kubernetes authenticates to the cluster
+# Auth Method: InjectedIdentity - Uses the provider pod's service account
+#
+# This configuration tells provider-kubernetes to use its own service account
+# to interact with the Kubernetes API. This is the most secure method for
+# in-cluster operations as it uses Kubernetes RBAC.
+
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: kubernetes-provider
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/scripts/cluster-manifests/crossplane-provider-kubernetes.yaml
+++ b/scripts/cluster-manifests/crossplane-provider-kubernetes.yaml
@@ -1,0 +1,14 @@
+# Provider: Kubernetes
+# Purpose: Enables Crossplane to create and manage Kubernetes resources (Services, ConfigMaps, etc.)
+# Restaurant Analogy: The "kitchen equipment supplier" - provides basic tools like pots, pans, and utensils
+# Version: v1.0.0 - Latest stable, compatible with Crossplane v2.0
+#
+# This provider allows Compositions to create any Kubernetes resource type,
+# making it essential for service deployments, config management, and RBAC.
+
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-kubernetes
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.0.0

--- a/scripts/cluster-manifests/environment-configs.yaml
+++ b/scripts/cluster-manifests/environment-configs.yaml
@@ -1,6 +1,11 @@
+# Crossplane Environment Configurations
+# Purpose: Platform-wide shared configuration accessible to all Compositions
+# Restaurant Analogy: The "house recipes and standards" - shared ingredients and settings
+#
+# EnvironmentConfigs provide a way to share configuration across all templates
+# without hardcoding values. Compositions can load these using the
+# function-environment-configs in their pipeline.
 ---
-# Platform-wide Environment Configurations
-# These are shared across all Crossplane templates
 apiVersion: apiextensions.crossplane.io/v1beta1
 kind: EnvironmentConfig
 metadata:

--- a/scripts/cluster-manifests/flux-catalog.yaml
+++ b/scripts/cluster-manifests/flux-catalog.yaml
@@ -1,6 +1,10 @@
-# Flux configuration for Crossplane template catalog
+# Flux GitOps: Catalog Watcher
+# Purpose: Monitors and syncs Crossplane templates from the catalog repository
+# Restaurant Analogy: The "menu updater" - automatically updates available dishes
+#
 # This configures Flux to watch the catalog repository which contains
-# references to all template-* repositories
+# references to all template-* repositories. When new templates are added
+# to the catalog, Flux automatically deploys them to the cluster.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository

--- a/scripts/cluster-manifests/provider-config.yaml
+++ b/scripts/cluster-manifests/provider-config.yaml
@@ -1,7 +1,0 @@
-apiVersion: kubernetes.crossplane.io/v1alpha1
-kind: ProviderConfig
-metadata:
-  name: kubernetes-provider
-spec:
-  credentials:
-    source: InjectedIdentity

--- a/scripts/cluster-manifests/provider-kubernetes.yaml
+++ b/scripts/cluster-manifests/provider-kubernetes.yaml
@@ -1,6 +1,0 @@
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-kubernetes
-spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.0.0


### PR DESCRIPTION
## Summary
This PR adds Crossplane provider-helm support and improves the organization of all manifest files for better maintainability and understanding.

## What's Changed

### 🚀 New Features
- **Provider-Helm Installation**: Adds provider-helm v1.0.0 to enable Helm chart deployments through Crossplane
- **Automatic Setup**: Updated `setup-cluster.sh` to install and configure provider-helm alongside provider-kubernetes

### 📝 Improvements
- **Renamed Manifests**: All provider manifests now have `crossplane-` prefix for clarity
  - `provider-kubernetes.yaml` → `crossplane-provider-kubernetes.yaml`
  - `provider-config.yaml` → `crossplane-provider-kubernetes-config.yaml`
- **Added Headers**: Every manifest now includes comprehensive header comments with:
  - Clear purpose descriptions
  - Restaurant analogies for easy understanding
  - Version and compatibility information

### 📚 Documentation
- Created `docs/provider-helm-usage.md` with complete usage guide and examples
- Added `scripts/cluster-manifests/MANIFESTS.md` explaining how functions work with providers

## Testing
The provider-helm has been installed and verified healthy:
```
provider-helm   True   True   xpkg.upbound.io/crossplane-contrib/provider-helm:v1.0.0
```

## Restaurant Analogy 🍳
Provider-helm acts as the **"pre-packaged meal supplier"** - it provides ready-to-use Helm charts (like Bitnami PostgreSQL, Redis) that can be deployed through Crossplane compositions.

## Closes
Closes #23 - Setup provider-helm for Helm chart deployments