### PR TITLE
feat: add cluster configuration scripts for environment switching

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Local development environment configuration
+# Copy this file to .env.local and adjust values as needed
+
+# Kubernetes Context
+# The kubectl context name for your local cluster
+# Common values: docker-desktop, rancher-desktop, minikube, kind-kind
+KUBE_CONTEXT=rancher-desktop

--- a/.env.openportal.example
+++ b/.env.openportal.example
@@ -1,0 +1,17 @@
+# OpenPortal production environment configuration
+# Copy this file to .env.openportal and add your credentials
+
+# Kubernetes Context
+# The kubectl context name for the OpenPortal cluster
+KUBE_CONTEXT=openportal
+
+# Cloudflare Configuration
+# Get these values from your Cloudflare dashboard
+CLOUDFLARE_API_TOKEN=your-api-token-here
+CLOUDFLARE_ZONE_ID=your-zone-id-here
+CLOUDFLARE_ACCOUNT_ID=your-account-id-here
+
+# DNS Configuration
+# The actual domain managed by Cloudflare
+DNS_ZONE=openportal.dev
+DNS_PROVIDER=cloudflare

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ service-*-template/
 *-kubeconfig
 *kubeconfig.yaml
 
+# Environment Variables
+.env
+.env.local
+.env.openportal
+
 # OS
 .DS_Store
 Thumbs.db

--- a/scripts/cluster-manifests/crossplane-provider-cloudflare.yaml
+++ b/scripts/cluster-manifests/crossplane-provider-cloudflare.yaml
@@ -1,0 +1,48 @@
+# Crossplane Provider Cloudflare
+# Purpose: Enables management of Cloudflare resources (DNS, Workers, etc.)
+# Restaurant Analogy: The "supplier" that provides DNS hosting services
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-cloudflare
+  annotations:
+    crossplane.io/version: "v2.0"
+    description: "Cloudflare provider for DNS and CDN management"
+spec:
+  # Using crossplane-contrib provider-cloudflare
+  # Alternative options:
+  # - ghcr.io/cdloh/provider-cloudflare:v0.1.0
+  # - xpkg.crossplane.io/crossplane-contrib/provider-cloudflare (if available)
+  package: ghcr.io/cdloh/provider-cloudflare:v0.1.0
+---
+apiVersion: cloudflare.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: cloudflare-provider
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      name: cloudflare-credentials
+      namespace: crossplane-system
+      key: credentials
+
+# NOTE: The secret is created by the config-openportal.sh script
+# 
+# To configure Cloudflare credentials:
+# 1. Copy .env.openportal.example to .env.openportal
+# 2. Add your Cloudflare API token and IDs to .env.openportal
+# 3. Run: ./scripts/config-openportal.sh
+#
+# The script will create the cloudflare-credentials secret automatically.
+#
+# How to get the Cloudflare token:
+# 1. Go to https://dash.cloudflare.com/profile/api-tokens
+# 2. Create Token → Use "Edit zone DNS" template
+# 3. Set permissions: Zone:DNS:Edit for your specific zone
+# 4. Add the token to .env.openportal as CLOUDFLARE_API_TOKEN
+#
+# For local development:
+# - Run: ./scripts/config-local.sh
+# - No Cloudflare credentials needed (uses mock DNS provider)

--- a/scripts/cluster-manifests/environment-configs.yaml
+++ b/scripts/cluster-manifests/environment-configs.yaml
@@ -14,9 +14,10 @@ metadata:
     crossplane.io/version: "v2.0"
     description: "DNS zone configuration for the platform"
 data:
-  # DNS zone for all DNS records
-  zone: openportal.dev
-
+  # Default to local development settings
+  zone: localhost
+  provider: mock
+  
   # Additional configuration that could be used
   # nameservers:
   #   - ns1.example.com

--- a/scripts/config-local.sh
+++ b/scripts/config-local.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Switch to local Kubernetes cluster context
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Switching to local cluster...${NC}"
+
+# Load local environment variables
+if [ -f "$WORKSPACE_DIR/.env.local" ]; then
+    source "$WORKSPACE_DIR/.env.local"
+    echo "✓ Loaded .env.local"
+else
+    echo -e "${YELLOW}Warning: .env.local not found${NC}"
+    echo "Using default: rancher-desktop"
+    KUBE_CONTEXT="rancher-desktop"
+fi
+
+# Switch to local context
+echo -e "${GREEN}Switching to context: ${KUBE_CONTEXT}${NC}"
+if ! kubectl config use-context "${KUBE_CONTEXT}"; then
+    echo -e "${RED}Error: Failed to switch to context '${KUBE_CONTEXT}'${NC}"
+    echo "Available contexts:"
+    kubectl config get-contexts
+    exit 1
+fi
+echo "✓ Switched to context: ${KUBE_CONTEXT}"
+
+# The default EnvironmentConfig is already set to local values in setup
+echo ""
+echo -e "${GREEN}Local cluster active!${NC}"
+echo ""
+echo "DNS Zone: localhost (default)"
+echo "DNS Provider: mock (default)"
+echo ""
+echo "You can now create DNS records that will resolve to localhost"

--- a/scripts/config-openportal.sh
+++ b/scripts/config-openportal.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Configure OpenPortal production cluster with Cloudflare settings
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Configuring OpenPortal cluster...${NC}"
+
+# Load OpenPortal environment variables
+if [ -f "$WORKSPACE_DIR/.env.openportal" ]; then
+    source "$WORKSPACE_DIR/.env.openportal"
+    echo "✓ Loaded .env.openportal"
+else
+    echo -e "${YELLOW}Warning: .env.openportal not found${NC}"
+    exit 1
+fi
+
+# Switch to OpenPortal context
+echo -e "${GREEN}Switching to context: ${KUBE_CONTEXT}${NC}"
+if ! kubectl config use-context "${KUBE_CONTEXT}"; then
+    echo -e "${RED}Error: Failed to switch to context '${KUBE_CONTEXT}'${NC}"
+    echo "Available contexts:"
+    kubectl config get-contexts
+    exit 1
+fi
+echo "✓ Switched to context: ${KUBE_CONTEXT}"
+
+# Create Cloudflare credentials secret
+# The ProviderConfig is already created by setup-cluster.sh and references this secret
+echo -e "${GREEN}Configuring Cloudflare credentials...${NC}"
+kubectl create secret generic cloudflare-credentials \
+    --from-literal=credentials="{\"api_token\":\"${CLOUDFLARE_API_TOKEN}\"}" \
+    --namespace crossplane-system \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+echo "✓ Cloudflare credentials configured (ProviderConfig already exists from setup)"
+
+# Update EnvironmentConfigs for OpenPortal
+echo -e "${GREEN}Updating EnvironmentConfigs...${NC}"
+kubectl apply -f - <<EOF
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: dns-config
+  namespace: crossplane-system
+data:
+  zone: "${DNS_ZONE}"
+  provider: "${DNS_PROVIDER}"
+---
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: cloudflare-config
+  namespace: crossplane-system
+data:
+  zone_id: "${CLOUDFLARE_ZONE_ID}"
+  account_id: "${CLOUDFLARE_ACCOUNT_ID}"
+EOF
+
+echo "✓ EnvironmentConfigs updated for OpenPortal"
+
+echo ""
+echo -e "${GREEN}OpenPortal cluster configuration complete!${NC}"
+echo ""
+echo "DNS Zone: ${DNS_ZONE}"
+echo "DNS Provider: ${DNS_PROVIDER}"
+echo "Cloudflare Zone ID: ${CLOUDFLARE_ZONE_ID}"
+echo "Cloudflare Account ID: ${CLOUDFLARE_ACCOUNT_ID}"
+echo ""
+echo "You can now create real DNS records in Cloudflare!"


### PR DESCRIPTION
## Summary

This PR adds cluster configuration scripts to easily switch between local development and production environments.

## What's New

- **Environment Configuration Scripts**:
  - `config-local.sh` - Switches to local cluster with mock DNS
  - `config-openportal.sh` - Configures OpenPortal cluster with Cloudflare DNS
  
- **Environment Templates**:
  - `.env.local.example` - Template for local development settings
  - `.env.openportal.example` - Template for production Cloudflare settings
  
- **Cloudflare Provider**:
  - Added provider-cloudflare manifest for production DNS management
  - Configured to use API token from environment variables

## How It Works

1. Copy the appropriate `.env.example` file and add your credentials
2. Run `./scripts/config-local.sh` for local development
3. Run `./scripts/config-openportal.sh` for production

The setup script (`setup-cluster.sh`) now defaults to local development settings, and production environments can override these using the config scripts.

## Testing

- [x] Tested local configuration switching
- [x] Tested Cloudflare DNS record creation on OpenPortal cluster
- [x] Verified environment configs update correctly