### PR TITLE
feat: unified reload-templates script for all Crossplane resources

### DIFF
--- a/docs/template-standards.md
+++ b/docs/template-standards.md
@@ -1,0 +1,281 @@
+# Template Standards and Guidelines
+
+This document defines the standards and structure that all Crossplane templates in the Open Service Portal must follow.
+
+## Repository Naming
+
+All template repositories must follow the pattern: `template-<resource-type>`
+
+Examples:
+- `template-namespace` - Kubernetes namespace provisioning
+- `template-dns-record` - DNS record management
+- `template-cloudflare-dnsrecord` - Cloudflare DNS integration
+
+## Required Directory Structure
+
+Every template MUST have this exact structure:
+
+```
+template-<name>/
+├── .github/
+│   └── workflows/
+│       └── release.yaml        # GitHub Actions release workflow
+├── configuration/
+│   ├── README.md               # Package constraints documentation
+│   ├── crossplane.yaml         # Crossplane package metadata
+│   ├── xrd.yaml               # Composite Resource Definition
+│   └── composition.yaml       # Composition implementation
+├── examples/
+│   ├── basic-<resource>.yaml  # Basic usage example
+│   └── <advanced>.yaml        # Advanced examples with features
+├── .gitignore                 # Must include *.xpkg
+├── kustomization.yaml         # Resource bundling
+├── rbac.yaml                  # RBAC permissions for Crossplane
+├── mise.toml                  # Tool management
+└── README.md                  # User documentation
+
+```
+
+## XRD Requirements
+
+### API Version and Metadata
+
+```yaml
+---
+apiVersion: apiextensions.crossplane.io/v2  # MUST use v2
+kind: CompositeResourceDefinition
+metadata:
+  name: <resources>.openportal.dev  # MUST use openportal.dev domain
+  labels:
+    terasky.backstage.io/generate-form: "true"  # REQUIRED for Backstage
+  annotations:
+    crossplane.io/version: "v2.0"
+    backstage.io/source-location: "url:https://github.com/open-service-portal/template-<name>"
+    openportal.dev/tags: "tag1,tag2"  # Comma-separated tags
+    openportal.dev/description: "Brief description"
+    openportal.dev/icon: "icon-name"  # Optional icon
+```
+
+### Spec Requirements
+
+```yaml
+spec:
+  scope: Namespaced  # MUST be Namespaced for v2 XRs
+  group: openportal.dev  # MUST use openportal.dev
+  names:
+    kind: <ResourceName>  # NO 'X' prefix (e.g., Namespace, not XNamespace)
+    plural: <resources>
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              # Define your resource properties here
+```
+
+## Composition Requirements
+
+```yaml
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: <resources>.openportal.dev
+  labels:
+    crossplane.io/xrd: <resources>.openportal.dev
+spec:
+  compositeTypeRef:
+    apiVersion: openportal.dev/v1alpha1
+    kind: <ResourceName>
+  
+  # Use Pipeline mode for composition functions
+  mode: Pipeline
+  pipeline:
+    - step: <step-name>
+      functionRef:
+        name: function-go-templating  # Or other functions
+      input:
+        # Function configuration
+```
+
+## Configuration Package (crossplane.yaml)
+
+```yaml
+apiVersion: meta.pkg.crossplane.io/v1
+kind: Configuration
+metadata:
+  name: configuration-<resource>
+  annotations:
+    meta.crossplane.io/maintainer: Open Service Portal Team
+    meta.crossplane.io/source: github.com/open-service-portal/template-<name>
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      Description of what this template provides
+    meta.crossplane.io/readme: |
+      Detailed README content
+spec:
+  crossplane:
+    version: ">=v1.14.0"
+  dependsOn:
+    - provider: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
+      version: ">=v0.13.0"
+```
+
+## Kustomization File
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Only include the Crossplane resources, not the examples
+resources:
+  - configuration/xrd.yaml
+  - configuration/composition.yaml
+  - rbac.yaml
+# Note: examples/*.yaml are intentionally NOT included
+```
+
+## RBAC File
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-<resource>-resources
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+    app.kubernetes.io/component: crossplane
+    app.kubernetes.io/part-of: <resource>-template
+rules:
+# Define permissions for resources your composition creates
+- apiGroups:
+  - ""
+  resources:
+  - <kubernetes-resources>
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+```
+
+## GitHub Actions Release Workflow
+
+Use the standard release workflow from `template-dns-record/.github/workflows/release.yaml`:
+- Triggers on version tags (v*.*.*)
+- Builds Crossplane Configuration package
+- Pushes to GitHub Container Registry
+- Creates GitHub release
+- Automatically creates PR to update catalog
+
+## Supporting Files
+
+### .gitignore
+```
+# Build artifacts
+*.xpkg
+```
+
+### mise.toml
+```toml
+[tools]
+crossplane-cli = "latest"
+```
+
+### configuration/README.md
+```markdown
+# Configuration package contents
+
+> Including YAML files that aren't Compositions or CompositeResourceDefinitions isn't supported.  
+> &mdash; [*Crossplane docs*](https://docs.crossplane.io/latest/packages/configurations/#build-the-package)
+```
+
+## Examples Structure
+
+Provide at least:
+1. **basic-<resource>.yaml** - Minimal configuration
+2. **<resource>-with-<feature>.yaml** - Advanced features
+
+Example format:
+```yaml
+# Example: Brief description
+apiVersion: openportal.dev/v1alpha1
+kind: <ResourceName>
+metadata:
+  name: example-name
+  namespace: default  # XR can be created in any namespace
+spec:
+  # Minimal required fields
+  name: example
+  # Additional fields with comments
+```
+
+## Documentation Requirements
+
+### Main README.md
+
+Must include:
+1. **Overview** - What the template provides
+2. **Components** - List of files and their purpose
+3. **Usage** - Basic and advanced examples
+4. **Features** - Key capabilities
+5. **Installation** - How to apply via catalog
+6. **Parameters** - Table of all spec fields
+7. **Restaurant Analogy** - Explain using restaurant metaphor
+
+## Versioning and Releases
+
+1. Use semantic versioning: `v<major>.<minor>.<patch>`
+2. Create annotated tags with detailed release notes
+3. GitHub Actions automatically:
+   - Builds Configuration package
+   - Pushes to ghcr.io
+   - Creates GitHub release
+   - Opens PR to update catalog
+
+## Testing Checklist
+
+Before releasing a template:
+
+- [ ] XRD uses `apiextensions.crossplane.io/v2`
+- [ ] Group is `openportal.dev`
+- [ ] Scope is `Namespaced`
+- [ ] No 'X' prefix in kind name
+- [ ] Has `terasky.backstage.io/generate-form` label
+- [ ] Has `backstage.io/source-location` annotation
+- [ ] Composition uses Pipeline mode
+- [ ] All required files present
+- [ ] RBAC permissions are minimal but sufficient
+- [ ] Examples work when applied
+- [ ] README is complete with restaurant analogy
+- [ ] Release workflow is configured
+
+## Common Mistakes to Avoid
+
+1. ❌ Using `platform.io` instead of `openportal.dev`
+2. ❌ Using v1 API instead of v2
+3. ❌ Missing `scope: Namespaced`
+4. ❌ Using 'X' prefix in resource names
+5. ❌ Missing kustomization.yaml
+6. ❌ Missing rbac.yaml
+7. ❌ Including examples in kustomization.yaml
+8. ❌ Missing backstage annotations
+
+## Reference Templates
+
+Use these as examples:
+- `template-dns-record` - Simple resource creation
+- `template-namespace` - Complex with quotas and policies
+- `template-whoami` - Application deployment
+- `template-cloudflare-dnsrecord` - External provider integration

--- a/scripts/reload-configurations.sh
+++ b/scripts/reload-configurations.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Reload Crossplane Configuration packages
+# This properly handles templates installed via Configuration packages
+
+set -e
+
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}🔄 Reloading Crossplane Configuration packages...${NC}"
+
+# Step 1: Delete all XRs first (they depend on XRDs)
+echo -e "${YELLOW}Deleting all XRs...${NC}"
+for xrd in $(kubectl get xrd -o name); do
+  resource_name=$(echo $xrd | sed 's/compositeresourcedefinition.apiextensions.crossplane.io\///')
+  echo "  Deleting XRs for $resource_name"
+  kubectl delete $resource_name --all 2>/dev/null || true
+done
+
+# Step 2: Delete all XRDs and Compositions
+echo -e "${YELLOW}Deleting XRDs and Compositions...${NC}"
+kubectl delete xrd --all 2>/dev/null || true
+kubectl delete composition --all 2>/dev/null || true
+
+# Step 3: Delete Configuration packages to force reinstall
+echo -e "${YELLOW}Deleting Configuration packages to force reinstall...${NC}"
+kubectl delete configuration.pkg.crossplane.io --all -n crossplane-system
+
+# Wait for deletion
+sleep 5
+
+# Step 4: Reconcile catalog (which contains the Configuration definitions)
+echo -e "${YELLOW}Reconciling catalog...${NC}"
+flux reconcile source git catalog -n flux-system
+flux reconcile kustomization catalog -n flux-system
+
+# Step 5: Wait for XRDs to be established
+echo -e "${YELLOW}Waiting for XRDs to be established...${NC}"
+sleep 10
+
+# Step 6: Check status
+echo -e "${YELLOW}Checking XRD status...${NC}"
+kubectl get xrd
+
+echo -e "${GREEN}✅ Configuration packages reloaded!${NC}"
+echo ""
+echo "Note: If XRDs are missing, check the Configuration package logs:"
+echo "  kubectl logs -n crossplane-system -l pkg.crossplane.io/package-name=configuration-dns-record"
+echo "  kubectl logs -n crossplane-system -l pkg.crossplane.io/package-name=configuration-namespace"

--- a/scripts/reload-templates.sh
+++ b/scripts/reload-templates.sh
@@ -1,17 +1,135 @@
 #!/bin/bash
 
-# Delete and reload all Crossplane templates
-echo "🔄 Reloading Crossplane templates..."
+# Unified script to reload all Crossplane templates
+# Handles both Configuration packages and direct Flux GitRepository sources
 
-# Delete XRDs and Compositions
-kubectl delete xrd --all 2>/dev/null
-kubectl delete composition --all 2>/dev/null
+set -e
 
-# Force Flux to reconcile all template sources
-for template in $(flux get sources git -n flux-system | grep template- | awk '{print $1}'); do
-  echo "♻️  Reconciling $template..."
-  flux reconcile source git $template -n flux-system
-  flux reconcile kustomization $template -n flux-system
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}╔══════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║     🔄 Reloading Crossplane Templates        ║${NC}"
+echo -e "${BLUE}╚══════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Step 1: Delete all XRs first (they depend on XRDs)
+echo -e "${YELLOW}📦 Step 1: Deleting all Composite Resources (XRs)...${NC}"
+for xrd in $(kubectl get xrd -o name 2>/dev/null); do
+  resource_name=$(echo $xrd | sed 's/compositeresourcedefinition.apiextensions.crossplane.io\///')
+  # Get the plural name for the resource
+  plural=$(kubectl get $xrd -o jsonpath='{.spec.names.plural}')
+  group=$(kubectl get $xrd -o jsonpath='{.spec.group}')
+  if [ ! -z "$plural" ]; then
+    echo "  ↳ Deleting XRs for $resource_name"
+    kubectl delete $plural.$group --all 2>/dev/null || true
+  fi
 done
 
-echo "✅ Templates reloaded!"
+# Step 2: Delete all XRDs and Compositions
+echo -e "${YELLOW}🗑️  Step 2: Deleting XRDs and Compositions...${NC}"
+kubectl delete xrd --all 2>/dev/null || true
+kubectl delete composition --all 2>/dev/null || true
+
+# Step 3: Handle Configuration packages (dns-record, namespace)
+echo -e "${YELLOW}📦 Step 3: Reloading Configuration packages...${NC}"
+configs=$(kubectl get configuration.pkg.crossplane.io -n crossplane-system -o name 2>/dev/null)
+if [ ! -z "$configs" ]; then
+  for config in $configs; do
+    config_name=$(echo $config | sed 's/configuration.pkg.crossplane.io\///')
+    echo "  ↳ Deleting $config_name..."
+    kubectl delete $config -n crossplane-system
+  done
+  
+  # Wait for deletion
+  echo "  ⏳ Waiting for Configuration packages to be deleted..."
+  sleep 5
+  
+  # Reconcile catalog to recreate Configuration packages
+  echo "  ♻️  Reconciling catalog to recreate Configuration packages..."
+  flux reconcile source git catalog -n flux-system
+  flux reconcile kustomization catalog -n flux-system
+else
+  echo "  ℹ️  No Configuration packages found"
+fi
+
+# Step 4: Handle direct Flux GitRepository templates (cloudflare, whoami)
+echo -e "${YELLOW}🔄 Step 4: Reconciling direct Flux templates...${NC}"
+# Get all template kustomizations from Flux
+templates=$(flux get kustomizations -n flux-system | grep -E "template-" | awk '{print $1}')
+if [ ! -z "$templates" ]; then
+  for template in $templates; do
+    echo "  ↳ Reconciling $template..."
+    flux reconcile kustomization $template -n flux-system
+  done
+else
+  echo "  ℹ️  No Flux template kustomizations found"
+fi
+
+# Step 5: Wait for XRDs to be established
+echo -e "${YELLOW}⏳ Step 5: Waiting for XRDs to be established...${NC}"
+sleep 10
+
+# Check for XRD establishment with timeout
+max_attempts=30
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+  xrd_count=$(kubectl get xrd --no-headers 2>/dev/null | wc -l | xargs)
+  if [ "$xrd_count" -gt 0 ]; then
+    established_count=$(kubectl get xrd -o json 2>/dev/null | jq '[.items[] | select(.status.conditions[]? | select(.type=="Established" and .status=="True"))] | length')
+    if [ "$xrd_count" -eq "$established_count" ] 2>/dev/null; then
+      echo -e "  ${GREEN}✓ All $xrd_count XRDs are established${NC}"
+      break
+    fi
+  fi
+  echo "  ⏳ Waiting for XRDs to be established (attempt $((attempt+1))/$max_attempts)..."
+  sleep 2
+  attempt=$((attempt+1))
+done
+
+# Step 6: Display status
+echo ""
+echo -e "${BLUE}📊 Final Status:${NC}"
+echo -e "${BLUE}────────────────────────────────────────────${NC}"
+
+# Show XRDs
+xrd_count=$(kubectl get xrd --no-headers 2>/dev/null | wc -l || echo "0")
+if [ $xrd_count -gt 0 ]; then
+  echo -e "${GREEN}✅ XRDs restored: $xrd_count${NC}"
+  kubectl get xrd 2>/dev/null | head -20
+else
+  echo -e "${RED}⚠️  No XRDs found${NC}"
+fi
+
+echo ""
+
+# Show Compositions
+comp_count=$(kubectl get composition --no-headers 2>/dev/null | wc -l || echo "0")
+if [ $comp_count -gt 0 ]; then
+  echo -e "${GREEN}✅ Compositions restored: $comp_count${NC}"
+  kubectl get composition 2>/dev/null | head -20
+else
+  echo -e "${RED}⚠️  No Compositions found${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}────────────────────────────────────────────${NC}"
+
+# Show Configuration package status
+echo ""
+echo -e "${YELLOW}Configuration Packages:${NC}"
+kubectl get configuration.pkg.crossplane.io -n crossplane-system 2>/dev/null || echo "  No Configuration packages found"
+
+echo ""
+echo -e "${GREEN}✅ Template reload complete!${NC}"
+echo ""
+echo -e "${BLUE}💡 Troubleshooting tips:${NC}"
+echo "  • If XRDs are missing, check Configuration package logs:"
+echo "    kubectl describe configuration.pkg.crossplane.io -n crossplane-system"
+echo "  • Check Flux logs for template issues:"
+echo "    kubectl logs -n flux-system deployment/kustomize-controller | tail -50"
+echo "  • Force reconcile a specific template:"
+echo "    flux reconcile kustomization <template-name> -n flux-system"


### PR DESCRIPTION
## Summary
- Created unified reload-templates.sh script that handles both Configuration packages and Flux GitRepository sources
- Added reload-configurations.sh as a specialized script for Configuration packages only
- Properly handles deletion and recreation of all XRDs and Compositions

## Changes
- **scripts/reload-templates.sh**: Unified script for all template types
- **scripts/reload-configurations.sh**: Specialized script for Configuration packages

## Features
- Handles both Configuration packages (dns-record, namespace) and direct Flux sources (cloudflare, whoami)  
- Properly deletes XRs before deleting XRDs (required dependency order)
- Deletes and recreates Configuration packages to force resource reinstallation
- Includes progress indicators and status reporting
- Provides troubleshooting tips for common issues

## Problem Solved
Configuration packages in Crossplane don't automatically recreate resources (XRDs, Compositions) when they're deleted manually. This script forces a full reload by deleting and recreating the Configuration resources themselves.