### PR TITLE
docs: add comprehensive namespaced XR guidelines to template standards

### DIFF
--- a/docs/template-standards.md
+++ b/docs/template-standards.md
@@ -109,51 +109,70 @@ spec:
 
 ### Critical Requirements for Namespaced XRs
 
-Since all XRs use `scope: Namespaced` in Crossplane v2, special care must be taken when using `provider-kubernetes` Object resources:
+Since all XRs use `scope: Namespaced` in Crossplane v2, special care must be taken when using `provider-kubernetes` Object resources.
+
+**IMPORTANT DISCOVERY:** Provider-kubernetes has TWO Object APIs:
+- `kubernetes.crossplane.io/v1alpha2` - **cluster-scoped** (CANNOT be used with namespaced XRs)
+- `kubernetes.m.crossplane.io/v1alpha1` - **namespace-scoped** (CAN be used with namespaced XRs)
+
+### The Solution: Use Namespace-Scoped Object API
 
 ```yaml
-# CORRECT: Object resource with namespaceSelector
-apiVersion: kubernetes.crossplane.io/v1alpha2
+# CORRECT: Use the namespace-scoped v1alpha1 API
+apiVersion: kubernetes.m.crossplane.io/v1alpha1  # Note the .m. in the API group!
 kind: Object
 metadata:
   name: {{ $xrName }}-deployment
+  namespace: {{ $xrNamespace }}  # REQUIRED: Object must be in XR's namespace
 spec:
   forProvider:
     manifest:
       # Your Kubernetes resource here
   providerConfigRef:
+    kind: ProviderConfig  # REQUIRED: kind field for v1alpha1
     name: kubernetes-provider
-  namespaceSelector:           # REQUIRED for namespaced XRs!
-    matchControllerRef: true   # Use the XR's namespace
 ```
 
 **Important Guidelines:**
 
-1. **Always include `namespaceSelector`** on Object resources
-   - Without it, Objects are cluster-scoped
-   - Namespaced XRs CANNOT create cluster-scoped resources (blocked by Crossplane v2)
-   - This will cause: "cannot apply cluster scoped composed resource for a namespaced composite resource"
+1. **Use the correct Object API version**
+   - Use `kubernetes.m.crossplane.io/v1alpha1` (namespace-scoped)
+   - NOT `kubernetes.crossplane.io/v1alpha2` (cluster-scoped)
+   - The `.m.` stands for "managed" and indicates namespace-scoped resources
 
-2. **Do NOT create namespaces from namespaced XRs**
+2. **Add namespace to Object metadata**
+   - Object resources need `metadata.namespace: {{ $xrNamespace }}`
+   - This places the Object resource itself in the XR's namespace
+
+3. **Include kind in providerConfigRef**
+   - The v1alpha1 API requires `kind: ProviderConfig`
+   - This is different from v1alpha2 which has a default
+
+4. **Create namespaced ProviderConfig**
+   - Create a ProviderConfig in the same namespace as your XRs
+   - Use `kubernetes.m.crossplane.io/v1alpha1` API for the ProviderConfig
+
+5. **Do NOT create namespaces from namespaced XRs**
    - The XR already exists in a namespace
    - Deploy all resources to the XR's namespace
    - Use `{{ .observed.composite.resource.metadata.namespace }}` in templates
 
-3. **Resource naming must be unique**
+6. **Resource naming must be unique**
    - Include XR name in resource names: `name: {{ $xrName }}-deployment`
    - This prevents conflicts when multiple XRs exist in the same namespace
 
-### Example: Correct Namespaced XR Pattern
+### Example: Complete Working Pattern
 
 ```yaml
 # In your go-templating function:
 {{- $xrName := .observed.composite.resource.metadata.name }}
 {{- $xrNamespace := .observed.composite.resource.metadata.namespace }}
 
-apiVersion: kubernetes.crossplane.io/v1alpha2
+apiVersion: kubernetes.m.crossplane.io/v1alpha1  # Namespace-scoped API
 kind: Object
 metadata:
   name: {{ $xrName }}-service
+  namespace: {{ $xrNamespace }}  # Object in XR's namespace
 spec:
   forProvider:
     manifest:
@@ -161,14 +180,28 @@ spec:
       kind: Service
       metadata:
         name: {{ $xrName }}           # Unique name
-        namespace: {{ $xrNamespace }} # Use XR's namespace
+        namespace: {{ $xrNamespace }} # Service in XR's namespace
   providerConfigRef:
+    kind: ProviderConfig  # Required for v1alpha1
     name: kubernetes-provider
-  namespaceSelector:
-    matchControllerRef: true          # CRITICAL!
 ```
 
-For more details, see [Crossplane PR #6588](https://github.com/crossplane/crossplane/pull/6588).
+### Setting up ProviderConfig
+
+You need a namespaced ProviderConfig:
+
+```yaml
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: kubernetes-provider
+  namespace: your-namespace  # Same namespace as XRs
+spec:
+  credentials:
+    source: InjectedIdentity
+```
+
+For more details, see [Crossplane PR #6588](https://github.com/crossplane/crossplane/pull/6588) which enforces that namespaced XRs cannot create cluster-scoped resources.
 
 ## Configuration Package (crossplane.yaml)
 
@@ -320,7 +353,10 @@ Before releasing a template:
 - [ ] Has `terasky.backstage.io/generate-form` label
 - [ ] Has `backstage.io/source-location` annotation
 - [ ] Composition uses Pipeline mode
-- [ ] Object resources have `namespaceSelector.matchControllerRef: true`
+- [ ] Object resources use `kubernetes.m.crossplane.io/v1alpha1` API (namespace-scoped)
+- [ ] Object resources have `metadata.namespace: {{ $xrNamespace }}`
+- [ ] providerConfigRef includes `kind: ProviderConfig`
+- [ ] Namespaced ProviderConfig exists in target namespace
 - [ ] No namespace creation from namespaced XRs
 - [ ] Resources use XR's namespace via template variable
 - [ ] Resource names include XR name for uniqueness
@@ -340,9 +376,12 @@ Before releasing a template:
 6. ❌ Missing rbac.yaml
 7. ❌ Including examples in kustomization.yaml
 8. ❌ Missing backstage annotations
-9. ❌ Object resources without `namespaceSelector` (causes cluster-scoped error)
-10. ❌ Creating namespaces from namespaced XRs
-11. ❌ Not using unique resource names (missing XR name prefix)
+9. ❌ Using `kubernetes.crossplane.io/v1alpha2` Object API (cluster-scoped) with namespaced XRs
+10. ❌ Missing `metadata.namespace` on Object resources
+11. ❌ Missing `kind: ProviderConfig` in providerConfigRef for v1alpha1 API
+12. ❌ No namespaced ProviderConfig in the XR's namespace
+13. ❌ Creating namespaces from namespaced XRs
+14. ❌ Not using unique resource names (missing XR name prefix)
 
 ## Reference Templates
 


### PR DESCRIPTION
## Summary
- Add dedicated section on namespaced XRs and Object resources
- Update testing checklist and common mistakes
- Provide clear examples of correct patterns

## Why This Matters

All our templates use `scope: Namespaced` for Crossplane v2 multi-tenancy. However, there's a critical requirement that Object resources must include `namespaceSelector` to be namespace-scoped. Without this, they become cluster-scoped and fail with:
```
cannot apply cluster scoped composed resource for a namespaced composite resource
```

## Documentation Added

### New Section: "Namespaced XRs and Object Resources"
- Explains the requirement for `namespaceSelector.matchControllerRef: true`
- Shows correct code patterns with examples
- Warns against creating namespaces from namespaced XRs
- Emphasizes unique resource naming

### Updated Testing Checklist
- Added checks for namespaceSelector presence
- Added check against namespace creation
- Added check for unique resource names

### Updated Common Mistakes
- Object resources without namespaceSelector
- Creating namespaces from namespaced XRs
- Not using unique resource names

## Reference
- Crossplane PR #6588 enforces these restrictions
- Discovered while debugging template-whoami XR failures

This documentation ensures all future templates follow correct patterns from the start.