### PR TITLE
feat: add kubernetes.m.crossplane.io managed API support

### DIFF
--- a/scripts/manifests-setup-cluster/crossplane-provider-kubernetes-managed-config.yaml
+++ b/scripts/manifests-setup-cluster/crossplane-provider-kubernetes-managed-config.yaml
@@ -1,0 +1,19 @@
+# ClusterProviderConfig: Kubernetes Managed API
+# Purpose: Configures how provider-kubernetes managed API authenticates to the cluster
+# Auth Method: InjectedIdentity - Uses the provider pod's service account
+#
+# This configuration enables the kubernetes.m.crossplane.io API which supports
+# namespaced XRs (Crossplane v2 style). The "m" stands for "managed" and this
+# API is required when using namespaced composite resources.
+#
+# Key Differences:
+# - kubernetes.crossplane.io = cluster-scoped Objects (legacy)
+# - kubernetes.m.crossplane.io = namespace-scoped Objects (v2 compatible)
+
+apiVersion: kubernetes.m.crossplane.io/v1alpha1
+kind: ClusterProviderConfig
+metadata:
+  name: kubernetes-provider
+spec:
+  credentials:
+    source: InjectedIdentity

--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -184,14 +184,20 @@ install_provider_kubernetes() {
         echo -e "${YELLOW}If the issue persists, review your provider configuration and try reapplying the manifest.${NC}"
     }
     
-    # Apply ProviderConfig
+    # Apply ProviderConfig for cluster-scoped API
     kubectl apply -f "$MANIFEST_DIR/crossplane-provider-kubernetes-config.yaml"
+    
+    # Apply ClusterProviderConfig for managed API (namespace-scoped, v2 compatible)
+    echo "Applying ClusterProviderConfig for managed API..."
+    kubectl apply -f "$MANIFEST_DIR/crossplane-provider-kubernetes-managed-config.yaml"
     
     # Apply RBAC for provider-kubernetes to manage all resources
     echo "Applying RBAC for provider-kubernetes..."
     kubectl apply -f "$MANIFEST_DIR/crossplane-provider-kubernetes-rbac.yaml"
     
     echo -e "${GREEN}✓ provider-kubernetes installed and configured with full RBAC${NC}"
+    echo "  - Cluster-scoped API (kubernetes.crossplane.io) configured"
+    echo "  - Managed API (kubernetes.m.crossplane.io) configured for namespaced XRs"
 }
 
 # Install Crossplane provider-cloudflare
@@ -386,7 +392,7 @@ print_summary() {
     echo "  ✓ Flux GitOps"
     echo "  ✓ Flux catalog watcher for Crossplane templates"
     echo "  ✓ Crossplane v2.0.0"
-    echo "  ✓ provider-kubernetes"
+    echo "  ✓ provider-kubernetes (both cluster & managed APIs)"
     echo "  ✓ provider-cloudflare (configure with config-openportal.sh)"
     echo "  ✓ Crossplane composition functions"
     


### PR DESCRIPTION
## Summary
- Add ClusterProviderConfig for kubernetes.m.crossplane.io managed API
- Update setup script to configure both cluster-scoped and managed APIs  
- Enable proper support for namespaced XRs with provider-kubernetes

## Context
The provider-kubernetes has two Object APIs:
- `kubernetes.crossplane.io/v1alpha2` - **cluster-scoped** (legacy, cannot be used with namespaced XRs)
- `kubernetes.m.crossplane.io/v1alpha1` - **namespace-scoped** (v2 compatible, required for namespaced XRs)

The "m" stands for "managed" and this API is required when using Crossplane v2 namespaced composite resources.

## Changes
1. Created new `crossplane-provider-kubernetes-managed-config.yaml` manifest with ClusterProviderConfig
2. Updated `setup-cluster.sh` to apply both configurations:
   - ProviderConfig for cluster-scoped API (backward compatibility)
   - ClusterProviderConfig for managed API (v2 namespaced XRs)
3. Updated script output to clarify both APIs are configured

## Testing
To test this change:
```bash
# Run the setup script to install/update provider-kubernetes
./scripts/setup-cluster.sh

# Verify ClusterProviderConfig is created
kubectl get clusterproviderconfigs.kubernetes.m.crossplane.io

# Verify both APIs are available
kubectl api-resources | grep kubernetes.crossplane.io
kubectl api-resources | grep kubernetes.m.crossplane.io
```

## Impact
- Templates using `kubernetes.crossplane.io` will continue to work
- Templates can now be updated to use `kubernetes.m.crossplane.io` for namespaced XR support
- No breaking changes - this is purely additive

## Next Steps
After this PR is merged, we should update templates like `template-whoami` to use the managed API instead of the cluster-scoped API.