### PR TITLE
fix: correct manifest directory path in config-openportal.sh

### DIFF
--- a/scripts/config-openportal.sh
+++ b/scripts/config-openportal.sh
@@ -5,7 +5,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
-MANIFEST_DIR="${SCRIPT_DIR}/manifests-config-openportal"
+MANIFEST_DIR="${SCRIPT_DIR}/manifests-config"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -123,8 +123,6 @@ EOF
 configure_flux_catalog_orders() {
     echo ""
     echo -e "${YELLOW}Configuring Flux to watch catalog-orders for cluster: ${CLUSTER_NAME}...${NC}"
-    
-    MANIFEST_DIR="$SCRIPT_DIR/manifests-config"
     
     # Apply catalog-orders configuration with environment substitution
     # Skip if Cloudflare is not needed (local clusters)


### PR DESCRIPTION
## Summary
Fixes a path error in the `config-openportal.sh` script that prevented it from finding and applying Cloudflare configuration manifests.

## Problem
The script was failing with the error:
```
./scripts/config-openportal.sh: line 53: /Users/felix/work/open-service-portal/portal-workspace/scripts/manifests-config-openportal/cloudflare-zone-openportal-dev.yaml: No such file or directory
error: no objects passed to apply
```

## Root Cause
The script was looking for manifest files in `manifests-config-openportal/` directory, but the actual directory name is `manifests-config/`.

## Solution
- Updated `MANIFEST_DIR` path from `manifests-config-openportal` to `manifests-config` (line 8)
- Removed redundant `MANIFEST_DIR` redefinition in `configure_flux_catalog_orders` function (line 127)

## Testing
After this fix, the script correctly locates and applies:
- `cloudflare-zone-openportal-dev.yaml`
- `environment-configs.yaml`
- `flux-catalog-orders.yaml`

## Impact
This fix allows the OpenPortal cluster configuration script to run successfully, enabling proper Cloudflare DNS management and environment configuration for production deployments.