### PR TITLE
fix: correct manifest directory path in config-openportal.sh

### DIFF
--- a/scripts/config-openportal.sh
+++ b/scripts/config-openportal.sh
@@ -5,7 +5,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
-MANIFEST_DIR="${SCRIPT_DIR}/manifests-config-openportal"
+MANIFEST_DIR="${SCRIPT_DIR}/manifests-config"
 
 # Colors for output
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
Fixes a path error in the `config-openportal.sh` script that prevented it from finding and applying Cloudflare configuration manifests.

## Problem
The script was failing with:
```
./scripts/config-openportal.sh: line 53: .../scripts/manifests-config-openportal/cloudflare-zone-openportal-dev.yaml: No such file or directory
```

## Solution
Updated `MANIFEST_DIR` path from `manifests-config-openportal` to `manifests-config` to match the actual directory structure.

## Testing
The script now correctly locates and applies all manifest files in the `scripts/manifests-config/` directory.