### PR TITLE
chore: add github-org-settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Cloned repositories (managed separately)
 .github/
+github-org-settings/
 app-portal/
 deploy-app-portal/
 catalog/


### PR DESCRIPTION
## Summary

Added `github-org-settings/` to `.gitignore` for better local workspace organization.

## Context

The `.github` repository (containing organization-wide GitHub settings) can be cloned locally under a different name to avoid conflicts with the regular `.github` directory.

## Changes

- Added `github-org-settings/` to `.gitignore`

This allows developers to:
- Clone the organization settings repo as `github-org-settings/` locally
- Avoid conflicts with the `.github/` workflow directory
- Keep the sync-repos.sh script working smoothly

Note: This is only a local naming convention. The remote repository remains `open-service-portal/.github.git`.