### PR TITLE
chore: update gitignore and CLAUDE.md documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ docusaurus/
 template-*/
 service-*-template/
 
-# Backstage Reference Repositories (for documentation search)
+# Reference Repositories (for documentation search)
 backstage*/
+crossplane*/
 
 # K8s Configs
 *.kubeconfig
@@ -34,6 +35,7 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+*.code-workspace
 
 # Temporary
 *.swp


### PR DESCRIPTION
## Summary
Updates `.gitignore` for reference repositories and corrects outdated script information in `CLAUDE.md`.

## Changes

### .gitignore Updates
- Add `crossplane*/` pattern to ignore Crossplane reference documentation (similar to existing `backstage*/`)
- Add `*.code-workspace` to IDE section for VS Code workspace files
- Update section comment from "Backstage Reference Repositories" to "Reference Repositories"

### CLAUDE.md Documentation Updates
Reflects changes from PRs #69-#76 that restructured cluster setup and template management:
- Remove references to deprecated `cluster-config-local.sh` and `cluster-config-openportal.sh`
- Document that `cluster-config.sh` now auto-detects the cluster from kubectl context
- Correct script names: `repos-sync.sh`, `cluster-cleanup.sh`
- Update External-DNS description as namespace-isolated (replaces provider-cloudflare)
- Remove "deprecated" label from cloudflare debug suite (now "legacy, for testing")
- Document multi-cluster catalog-orders path configuration in Flux
- Update gitignore patterns documentation to include `crossplane*/`

## Context
These updates ensure the documentation accurately reflects the current state of the project after recent infrastructure improvements, particularly the External-DNS migration and multi-cluster support enhancements.

## Test plan
- [x] Verified that `crossplane-docs/` and `crossplane-provider-kubernetes/` are ignored
- [x] Verified that `*.code-workspace` files are ignored
- [x] Confirmed CLAUDE.md script references match actual files in `scripts/`
- [x] Validated that all mentioned scripts exist and are executable

🤖 Generated with Claude Code (https://claude.ai/code)