### PR TITLE
fix: reduce External-DNS timeout to prevent setup hanging

### DIFF
--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -214,10 +214,11 @@ install_external_dns() {
     
     kubectl apply -f "$MANIFEST_DIR/external-dns.yaml"
     
-    # Wait for External-DNS deployment to be ready
-    echo "Waiting for External-DNS deployment to be ready..."
-    kubectl rollout status deployment/external-dns -n external-dns --timeout=300s || {
-        echo -e "${YELLOW}External-DNS deployment did not become ready within the timeout period.${NC}"
+    # Wait for External-DNS deployment to be ready (with shorter timeout since credentials come later)
+    echo "Waiting for External-DNS deployment to be ready (10s timeout)..."
+    kubectl rollout status deployment/external-dns -n external-dns --timeout=10s || {
+        echo -e "${YELLOW}⚠ External-DNS is not ready yet (this is expected if Cloudflare credentials are not configured)${NC}"
+        echo -e "${YELLOW}External-DNS will start working after you run the cluster config script to add credentials.${NC}"
         echo -e "${YELLOW}You can check the status with:${NC} kubectl get deployment -n external-dns"
         echo -e "${YELLOW}Check logs with:${NC} kubectl logs -n external-dns deployment/external-dns"
     }


### PR DESCRIPTION
## Summary

This PR improves the cluster setup script to prevent it from hanging when External-DNS credentials haven't been configured yet.

## Problem

The setup script was waiting up to 5 minutes for External-DNS to become ready, but External-DNS cannot start without Cloudflare credentials. Since credentials are added by the config script (run after setup), this caused the setup to hang unnecessarily.

## Solution

- Reduced External-DNS timeout from 300s to 10s
- Added clearer messaging indicating that missing credentials are expected during initial setup
- Guides users to run the cluster config script next to add credentials
- Setup continues smoothly even when External-DNS isn't ready

## Testing

Tested on OpenPortal cluster:
- Setup script now completes quickly without hanging
- External-DNS starts successfully after running config script
- Clear user guidance provided at each step