### PR TITLE
feat: auto-run cluster config from setup if environment file exists

### DIFF
--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -427,6 +427,41 @@ print_summary() {
     echo "============================================================"
 }
 
+# Run cluster configuration if environment file exists
+run_cluster_config() {
+    echo ""
+    echo -e "${BLUE}Checking for cluster configuration...${NC}"
+    
+    # Get current context
+    CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "")
+    ENV_FILE="${WORKSPACE_DIR}/.env.${CURRENT_CONTEXT}"
+    
+    if [ -f "$ENV_FILE" ]; then
+        echo -e "${GREEN}Environment file found: .env.${CURRENT_CONTEXT}${NC}"
+        echo ""
+        echo -e "${YELLOW}Running cluster configuration to set up credentials...${NC}"
+        echo "============================================================"
+        
+        # Run the config script
+        "${SCRIPT_DIR}/cluster-config.sh"
+        
+        echo ""
+        echo -e "${GREEN}✅ Configuration applied successfully!${NC}"
+        echo ""
+    else
+        echo -e "${YELLOW}No environment file found for context: ${CURRENT_CONTEXT}${NC}"
+        echo ""
+        echo "To configure credentials later:"
+        echo "1. Create environment file:"
+        echo -e "   ${GREEN}cp .env.rancher-desktop.example .env.${CURRENT_CONTEXT}${NC}"
+        echo "2. Edit with your credentials:"
+        echo -e "   ${GREEN}vim .env.${CURRENT_CONTEXT}${NC}"
+        echo "3. Run configuration:"
+        echo -e "   ${GREEN}./scripts/cluster-config.sh${NC}"
+        echo ""
+    fi
+}
+
 # Main execution
 main() {
     check_prerequisites
@@ -441,6 +476,7 @@ main() {
     install_environment_configs  # Install platform-wide configs
     create_backstage_service_account
     print_summary
+    run_cluster_config  # Run configuration if environment file exists
 }
 
 # Run main function


### PR DESCRIPTION
## Summary

This PR enhances the cluster setup script to automatically run configuration if an environment file exists, creating a seamless single-command installation experience.

## Problem

Previously, users had to:
1. Run `./scripts/cluster-setup.sh` to install infrastructure
2. Manually run `./scripts/cluster-config.sh` to configure credentials

This two-step process was easy to forget and services like External-DNS wouldn't work until the second step was completed.

## Solution

Added automatic configuration detection and execution:
- The setup script now checks for `.env.${kubectl-context}` file
- If found, automatically runs the configuration script
- If not found, provides clear instructions for manual setup

## Implementation

Added `run_cluster_config()` function that:
- Detects current kubectl context
- Checks for corresponding environment file
- Runs configuration automatically if file exists
- Provides helpful guidance if file is missing

## Benefits

- **Single-command setup**: Just run `./scripts/cluster-setup.sh` when env file is prepared
- **Seamless experience**: External-DNS and other services configured automatically
- **Backward compatible**: Manual configuration still works
- **Flexible**: `cluster-config.sh` remains standalone for reconfiguration

## Testing

Tested with multiple cluster contexts:
- ✅ Auto-config works when `.env.openportal` exists
- ✅ Clear instructions shown when env file missing
- ✅ Manual config still works independently
- ✅ Services start correctly after auto-config

## Usage

```bash
# Prepare environment file first
cp .env.rancher-desktop.example .env.rancher-desktop
vim .env.rancher-desktop

# Single command setup + config
./scripts/cluster-setup.sh

# Or run config separately for updates
./scripts/cluster-config.sh
```