### PR TITLE
fix: remove hardcoded path from template-release.sh

### DIFF
--- a/scripts/template-release.sh
+++ b/scripts/template-release.sh
@@ -31,13 +31,17 @@ fi
 
 TEMPLATE_NAME=$1
 VERSION_ARG=${2:-""}
-TEMPLATE_DIR="/Users/felix/work/open-service-portal/portal-workspace/${TEMPLATE_NAME}"
+
+# Get script and workspace directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="${WORKSPACE_DIR}/${TEMPLATE_NAME}"
 
 # Check if template directory exists
 if [ ! -d "${TEMPLATE_DIR}" ]; then
     echo -e "${RED}Error: Template directory not found: ${TEMPLATE_DIR}${NC}"
     echo "Available templates:"
-    ls -d /Users/felix/work/open-service-portal/portal-workspace/template-* 2>/dev/null | xargs -n1 basename || echo "No templates found"
+    ls -d "${WORKSPACE_DIR}"/template-* 2>/dev/null | xargs -n1 basename || echo "No templates found"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes hardcoded path in `template-release.sh` that prevented the script from working on machines other than Felix's.

## Problem

The script had a hardcoded path:
```bash
TEMPLATE_DIR="/Users/felix/work/open-service-portal/portal-workspace/${TEMPLATE_NAME}"
```

This caused the script to fail on any other machine.

## Solution

Now uses dynamic path detection:
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
WORKSPACE_DIR="$(dirname "$SCRIPT_DIR")"
TEMPLATE_DIR="${WORKSPACE_DIR}/${TEMPLATE_NAME}"
```

## Testing

Script now works correctly regardless of:
- Username
- Directory structure  
- Operating system (as long as it supports bash)