### PR TITLE
feat: add system namespace creation for infrastructure XRs

### DIFF
--- a/scripts/cluster-config.sh
+++ b/scripts/cluster-config.sh
@@ -249,6 +249,12 @@ echo "Ensuring demo namespace exists..."
 kubectl create namespace demo --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
 echo -e "${GREEN}✓ Demo namespace ready${NC}"
 
+# Create system namespace for infrastructure XRs
+echo "Creating system namespace for infrastructure XRs..."
+kubectl create namespace system --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>&1
+kubectl label namespace system purpose=infrastructure-xrs --overwrite >/dev/null 2>&1
+echo -e "${GREEN}✓ System namespace created for infrastructure XRs${NC}"
+
 # Run common configurations
 update_backstage_config
 configure_flux_catalog_orders


### PR DESCRIPTION
## Summary

This PR adds creation of a dedicated "system" namespace for infrastructure XRs (Crossplane Composite Resources).

## Context

We're moving ManagedNamespace XRDs from cluster-scoped to namespaced resources to fix Flux reconciliation issues. The "system" namespace provides a clear separation for infrastructure-level resources.

## Changes

- Added system namespace creation in `cluster-config.sh`
- Labels namespace with `purpose=infrastructure-xrs` for clarity
- Namespace is created alongside the existing demo namespace

## Benefits

- Clear separation of infrastructure XRs from application resources
- Fixes Flux reconciliation issues with API server cache
- Aligns with Kubernetes best practices for system resources
- Provides consistent location for cluster-wide infrastructure XRs

## Related

- template-namespace v2.1.0 update (changes XRD to namespaced)
- catalog-orders update (moves XRs to system namespace)
- Fixes the "namespace not specified" error in Flux