### PR TITLE
fix: configure External-DNS to watch all namespaces

### DIFF
--- a/scripts/manifests-setup-cluster/external-dns.yaml
+++ b/scripts/manifests-setup-cluster/external-dns.yaml
@@ -131,6 +131,7 @@ spec:
         - --source=crd
         - --crd-source-apiversion=externaldns.openportal.dev/v1alpha1
         - --crd-source-kind=DNSEndpoint
+        - --namespace=  # Watch all namespaces (empty value = all)
         - --provider=cloudflare  # Default to non-proxied, can be overridden per record
         - --domain-filter=openportal.dev  # Only manage records in this zone
         - --policy=sync  # sync = create/update/delete as needed


### PR DESCRIPTION
## Summary
- Fix External-DNS to watch DNSEndpoints across all namespaces
- Previously only watched its own namespace, causing DNSEndpoints in other namespaces to be ignored
- This resolves CloudflareDNSRecord XRs not being processed properly

## Problem
External-DNS was configured without the `--namespace=` flag, which meant it only watched for DNSEndpoint resources in the `external-dns` namespace. When Crossplane created DNSEndpoints in user namespaces (e.g., `test`, `demo`), External-DNS couldn't see or process them, resulting in:
- DNS records not being created in Cloudflare
- CloudflareDNSRecord XRs showing as "not ready" in Backstage
- WhoAmIService XRs reporting DNS as not ready

## Solution
Added `--namespace=` flag to External-DNS deployment arguments. An empty value for this flag tells External-DNS to watch all namespaces.

## Related Changes
- CloudflareDNSRecord template fix already merged: open-service-portal/template-cloudflare-dnsrecord@9c3c63b

## Testing
- Applied to local cluster and verified External-DNS now processes DNSEndpoints from all namespaces
- CloudflareDNSRecord XRs now show as ready
- DNS records are successfully created in Cloudflare