### PR TITLE
feat: add cluster-kubeconfig.sh script for kubectl config management

### DIFF
--- a/scripts/cluster-kubeconfig.sh
+++ b/scripts/cluster-kubeconfig.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# cluster-kubeconfig.sh - Update kubectl config from a context-specific kubeconfig file
+#
+# Usage:
+#   ./cluster-kubeconfig.sh <context>
+#
+# Description:
+#   Extracts cluster configuration and credentials from a <context>.kubeconfig file
+#   and updates your ~/.kube/config with the information. 
+#
+# Examples:
+#   ./cluster-kubeconfig.sh openportal     # Updates from openportal.kubeconfig
+#   ./cluster-kubeconfig.sh rancher-desktop # Updates from rancher-desktop.kubeconfig
+
+set -euo pipefail
+
+# Get context name from argument
+CONTEXT="${1:?Usage: $0 <context>}"
+
+# Define paths
+KUBECONFIG_FILE="${CONTEXT}.kubeconfig"
+KUBE_CONFIG_HOME="$HOME/.kube/config"
+
+# 1. Verify kubeconfig file exists
+if [[ ! -f "$KUBECONFIG_FILE" ]]; then
+    echo "❌ Error: $KUBECONFIG_FILE not found in current directory"
+    echo "   Available kubeconfig files:"
+    ls -1 *.kubeconfig 2>/dev/null | sed 's/^/   - /' || echo "   None found"
+    exit 1
+fi
+
+# 2. Get cluster info from KUBECONFIG_FILE using yq
+# First get the current context from the file
+CURRENT_CONTEXT=$(yq '.current-context' "$KUBECONFIG_FILE")
+
+# If no current context, try to use first context or match by name
+if [[ "$CURRENT_CONTEXT" == "null" ]] || [[ -z "$CURRENT_CONTEXT" ]]; then
+    # Try to find a context matching the CONTEXT name
+    CURRENT_CONTEXT=$(yq ".contexts[] | select(.name == \"$CONTEXT\") | .name" "$KUBECONFIG_FILE")
+    
+    # If still not found, use the first context
+    if [[ -z "$CURRENT_CONTEXT" ]]; then
+        CURRENT_CONTEXT=$(yq '.contexts[0].name' "$KUBECONFIG_FILE")
+    fi
+fi
+
+echo "   Using context: $CURRENT_CONTEXT"
+
+# Get cluster and user names from the context
+CLUSTER=$(yq ".contexts[] | select(.name == \"$CURRENT_CONTEXT\") | .context.cluster" "$KUBECONFIG_FILE")
+USER=$(yq ".contexts[] | select(.name == \"$CURRENT_CONTEXT\") | .context.user" "$KUBECONFIG_FILE")
+
+# Get cluster details using the cluster name
+SERVER=$(yq ".clusters[] | select(.name == \"$CLUSTER\") | .cluster.server" "$KUBECONFIG_FILE")
+CERT_DATA=$(yq ".clusters[] | select(.name == \"$CLUSTER\") | .cluster.certificate-authority-data" "$KUBECONFIG_FILE")
+
+# Get user token using the user name
+TOKEN=$(yq ".users[] | select(.name == \"$USER\") | .user.token" "$KUBECONFIG_FILE")
+
+echo "   Cluster: $CLUSTER Server: $SERVER User: $USER"
+
+# 3. Validate kubectl config exists for given context - create it if not
+if ! kubectl config get-contexts "$CONTEXT" &>/dev/null; then
+    echo "⚠️  Context $CONTEXT not found in kube config, creating it"
+    # Create cluster without cert data first
+    kubectl config set-cluster "$CONTEXT" --server="$SERVER"
+    # Set certificate data separately
+    kubectl config set clusters."$CONTEXT".certificate-authority-data "$CERT_DATA"
+    # Create context
+    kubectl config set-context "$CONTEXT" --cluster="$CONTEXT" --user="$USER"
+fi
+
+# 4. Update kubectl config with token
+kubectl config set-credentials "$USER" --token="$TOKEN"
+kubectl config use-context "$CONTEXT"
+echo "✅ Updated kubectl config with $CONTEXT context"


### PR DESCRIPTION
## Summary
Adds a new utility script to simplify kubectl configuration management from kubeconfig files.

## Purpose
When working with multiple Kubernetes clusters, managing kubectl configurations can be complex. This script automates the process of extracting credentials from downloaded kubeconfig files and updating the local kubectl config.

## Features
- 🔍 **Smart extraction**: Reads cluster, user, and token from kubeconfig files using yq
- 🔄 **Multi-context support**: Handles files with multiple contexts/users
- ✨ **Create or update**: Creates new contexts or updates existing ones
- 🔒 **Security**: Preserves certificate authority data for TLS verification
- 📝 **Well-documented**: Includes comprehensive usage documentation

## Usage
```bash
# Update kubectl config from openportal.kubeconfig
./scripts/cluster-kubeconfig.sh openportal

# Update from rancher-desktop.kubeconfig
./scripts/cluster-kubeconfig.sh rancher-desktop
```

## Implementation Details
- Uses `yq` for reliable YAML parsing (no regex/grep hacks)
- Follows the existing script patterns in the repository
- Includes proper error handling with `set -euo pipefail`
- Portable shebang using `#!/usr/bin/env bash`

## Testing
- [x] Tested with single-context kubeconfig files
- [x] Tested with multi-context kubeconfig files
- [x] Verified certificate data preservation
- [x] Confirmed context switching works

## Requirements
- `yq` - YAML processor (install with `brew install yq`)
- `kubectl` - Kubernetes CLI