### PR TITLE
feat: support multiple contexts on same cluster with unique Kustomization names

### DIFF
--- a/scripts/manifests-config/flux-catalog-orders.yaml
+++ b/scripts/manifests-config/flux-catalog-orders.yaml
@@ -1,6 +1,7 @@
 # Flux GitOps: Catalog Orders Watcher
 # Purpose: Monitors and syncs XR instances created by Backstage templates
-# Uses ${CURRENT_CONTEXT} environment variable to determine path
+# Creates a context-specific Kustomization: catalog-orders-${CURRENT_CONTEXT}
+# This allows multiple contexts to coexist on the same cluster
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -16,7 +17,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: catalog-orders
+  name: catalog-orders-${CURRENT_CONTEXT}
   namespace: flux-system
 spec:
   interval: 1m0s


### PR DESCRIPTION
## Summary

This PR modifies the cluster configuration script to support multiple kubectl contexts on the same physical cluster without conflicts. Each context gets its own uniquely-named Flux Kustomization.

## Problem Solved

Previously, when two users with different context names (e.g., `openportal` and `osp-openportal`) ran the cluster-config script on the same cluster:
- The Flux Kustomization would be overwritten each time
- Only the last context's path would be watched
- Resources would appear/disappear based on who ran the script last

## Solution

**Context-specific Kustomization names**: Each context creates a Kustomization named `catalog-orders-${CURRENT_CONTEXT}` instead of just `catalog-orders`.

## Changes

### 1. Modified `flux-catalog-orders.yaml`
- Kustomization name now includes context: `catalog-orders-${CURRENT_CONTEXT}`
- Added comments explaining the multi-context support

### 2. Enhanced `cluster-config.sh`
- Updated messages to show the context-specific Kustomization name
- Added listing of all active catalog-orders Kustomizations after configuration
- Force reconciliation for the context-specific Kustomization

## How It Works

When users run the script with different contexts on the same cluster:

```bash
# User 1 with context "openportal"
./cluster-config.sh
# Creates: catalog-orders-openportal watching ./openportal

# User 2 with context "osp-openportal"  
./cluster-config.sh
# Creates: catalog-orders-osp-openportal watching ./osp-openportal

# Result: Both Kustomizations coexist!
kubectl get kustomizations -n flux-system | grep catalog-orders
# catalog-orders-openportal       True    Applied revision: main@sha1:...
# catalog-orders-osp-openportal   True    Applied revision: main@sha1:...
```

## Benefits

✅ **No more overwriting** - Each context maintains its own Kustomization
✅ **Multiple teams can share a cluster** - Each with their own GitOps path
✅ **Clear visibility** - Script shows all active Kustomizations
✅ **Backward compatible** - Existing single-context setups continue to work

## Testing

1. Run the script with context `openportal`:
   ```bash
   kubectl config use-context openportal
   ./scripts/cluster-config.sh
   ```

2. Run the script with context `osp-openportal`:
   ```bash
   kubectl config use-context osp-openportal
   ./scripts/cluster-config.sh
   ```

3. Verify both Kustomizations exist:
   ```bash
   kubectl get kustomizations -n flux-system | grep catalog-orders
   ```

## Note

The catalog-orders repository should have directories matching the context names:
- `openportal/` - Resources for openportal context
- `osp-openportal/` - Resources for osp-openportal context
- etc.

This change pairs well with the auto-generated kustomization.yaml files per cluster directory (PR open-service-portal/catalog-orders#11).