### PR TITLE
docs: add Backstage Rackspace debugging guide

### DIFF
--- a/docs/backstage-rackspace-debugging-guide.md
+++ b/docs/backstage-rackspace-debugging-guide.md
@@ -92,16 +92,6 @@ kubectl port-forward -n app-portal deployment/app-portal 7007:7007
 {"level":"warn","message":"Signing key has expired"}
 ```
 
-## Useful Aliases
-
-```bash
-# Add to ~/.bashrc or ~/.zshrc
-alias bspod='kubectl get pods -n app-portal -o jsonpath="{.items[0].metadata.name}"'
-alias bslogs='kubectl logs $(bspod) -n app-portal'
-alias bslogsf='kubectl logs -f $(bspod) -n app-portal'
-alias bsrestart='kubectl delete pod $(bspod) -n app-portal'
-```
-
 ## Troubleshooting Checklist
 
 1. **Pod running?** → `kubectl get pods -n app-portal`


### PR DESCRIPTION
## Summary
- Add debugging guide for Backstage deployment on Rackspace cluster
- Include kubectl commands for log access and troubleshooting
- Add useful aliases and common log patterns

## Changes
- New file: `docs/backstage-rackspace-debugging-guide.md`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Rackspace deployment debugging guide for Backstage. Covers Quick Start (cluster access, resource discovery), essential kubectl commands for inspecting pods and logs, searching logs for common error patterns, configuration checks (env vars, secrets, configmaps), pod operations (restart, scale, exec, port-forward), common log patterns, useful shell aliases, and a troubleshooting checklist to speed diagnosis and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->