### PR TITLE
feat: add xrd-transform wrapper script with path resolution

### DIFF
--- a/docs/ingestor-v2-architecture-concept.md
+++ b/docs/ingestor-v2-architecture-concept.md
@@ -1,0 +1,577 @@
+# Ingestor v2 Architecture Concept
+
+## Vision
+Redesign the ingestor as three independent, composable tools that follow the Unix philosophy: do one thing well. Each tool can be used standalone or orchestrated together, with complete control over template generation through Eta templates.
+
+## Architecture Decisions
+
+### Core Principles
+1. **Three Independent Tools** - Extract, Transform, Provide (complete implementations, not frameworks)
+2. **Replaceable Tools** - Each tool can be replaced by external alternatives (not plugins, but complete replacements)
+3. **Template-Driven** - Full control via Eta templates for transformation
+4. **File-Based Interface** - Tools communicate via files/JSON, enabling easy replacement
+5. **Dual Execution** - Run embedded in Backstage or as external processes
+
+### Tool Separation & Replaceability
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   EXTRACT   │────▶│  TRANSFORM  │────▶│   PROVIDE   │
+└─────────────┘     └─────────────┘     └─────────────┘
+      │                    │                    │
+      ▼                    ▼                    ▼
+ K8s API/Files        Templates            Backstage
+                    (Eta Engine)         (Plugin Only)
+
+      OR                  OR                   OR
+
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   kubectl   │────▶│   Custom    │────▶│   GitHub    │
+│  get xrd    │     │   Script    │     │   Actions   │
+└─────────────┘     └─────────────┘     └─────────────┘
+```
+
+**Key Design Decision**: Each tool is a complete, standalone implementation. We don't build plugin systems within the tools. Instead, the tools communicate via standard file formats (JSON/YAML), allowing users to replace any tool entirely with their own implementation or existing tools.
+
+### Tool Interface Contracts
+
+Each tool has a clear input/output contract, enabling replacement:
+
+1. **Extract Output** → JSON file with structure:
+   ```json
+   {
+     "source": "kubernetes|file|git",
+     "timestamp": "ISO-8601",
+     "xrd": { /* XRD object */ },
+     "metadata": { /* extraction context */ }
+   }
+   ```
+
+2. **Transform Input** → Extract's JSON output
+   **Transform Output** → Backstage YAML/JSON entities
+
+3. **Provide Input** → Directory of Backstage entities
+   **Provide Output** → Entities in Backstage catalog
+
+## Detailed Architecture
+
+### 1. Extract Tool (`@openportal/xrd-extract`)
+
+**Purpose**: Extract XRDs from various sources
+
+**CLI Usage**:
+```bash
+xrd-extract --source kubernetes --cluster production --output xrds/
+xrd-extract --source file --path ./my-xrd.yaml --output xrds/
+xrd-extract --source git --repo https://github.com/org/templates --output xrds/
+```
+
+**Library Usage**:
+```typescript
+import { extract } from '@openportal/xrd-extract';
+
+const xrds = await extract({
+  source: 'kubernetes',
+  cluster: 'production',
+  filters: { labels: { 'backstage.io/enabled': 'true' } }
+});
+```
+
+**Output Format**: JSON with XRD + metadata
+```json
+{
+  "source": "kubernetes",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "xrd": { /* Original XRD */ },
+  "metadata": {
+    "cluster": "production",
+    "namespace": "crossplane-system"
+  }
+}
+```
+
+**Can Be Replaced With** (external tools, not plugins):
+```bash
+# Using kubectl instead of xrd-extract
+kubectl get xrd -o json | jq '{
+  source: "kubernetes",
+  timestamp: now|todate,
+  xrd: .,
+  metadata: {cluster: "production"}
+}' > xrd.json
+
+# Using a simple shell script
+#!/bin/bash
+cat my-xrd.yaml | yq eval -o=json '{
+  source: "file",
+  timestamp: "'$(date -Iseconds)'",
+  xrd: .,
+  metadata: {path: "'$1'"}
+}' > xrd.json
+```
+
+### 2. Transform Tool (`@openportal/xrd-transform`)
+
+**Purpose**: Transform XRDs into Backstage templates using Eta templates
+
+**CLI Usage**:
+```bash
+xrd-transform --input xrds/ --templates ./templates --output catalog/
+xrd-transform --input xrd.json --template-dir ./my-templates --output catalog/
+```
+
+**Library Usage**:
+```typescript
+import { transform } from '@openportal/xrd-transform';
+
+const backstageEntities = await transform({
+  xrd: xrdData,
+  templateDir: './templates',
+  context: { /* additional context */ }
+});
+```
+
+**Template Structure**:
+```
+templates/
+├── metadata.yaml          # Template configuration
+├── backstage/
+│   ├── default.eta       # Default Backstage template
+│   ├── simple.eta        # Simple form template
+│   └── advanced.eta      # Advanced template with all features
+├── wizard/
+│   ├── default.eta       # Default wizard configuration
+│   ├── gitops.eta        # GitOps-focused wizard
+│   └── multi-cluster.eta # Multi-cluster wizard
+└── steps/
+    ├── default.eta       # Default steps
+    ├── github-pr.eta     # GitHub PR creation
+    ├── gitlab-mr.eta     # GitLab MR creation
+    └── direct-apply.eta  # Direct kubectl apply
+
+```
+
+**Template Selection via XRD Annotation**:
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: databases.platform.io
+  annotations:
+    # Select which templates to use
+    backstage.io/template: advanced      # Use advanced.eta
+    backstage.io/wizard: gitops          # Use gitops.eta wizard
+    backstage.io/steps: github-pr        # Use github-pr.eta steps
+    # Or use default if not specified
+```
+
+**Eta Template Example** (`backstage/advanced.eta`):
+```eta
+<%#
+  Available variables:
+  - xrd: The full XRD object
+  - metadata: Extraction metadata
+  - helpers: Utility functions
+%>
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: <%= helpers.slugify(xrd.metadata.name) %>
+  title: <%= helpers.extractTitle(xrd) %>
+  description: <%= xrd.metadata.annotations?.['backstage.io/description'] || 'Manage ' + xrd.spec.names.kind %>
+  tags:
+    - crossplane
+    - <%= xrd.spec.group %>
+    <% if (xrd.metadata.labels) { %>
+    <% Object.entries(xrd.metadata.labels).forEach(([key, value]) => { %>
+    - <%= value %>
+    <% }) %>
+    <% } %>
+spec:
+  owner: <%= xrd.metadata.annotations?.['backstage.io/owner'] || 'platform-team' %>
+  type: crossplane-resource
+
+  <%# Include the wizard %>
+  <%= include('wizard/' + (xrd.metadata.annotations?.['backstage.io/wizard'] || 'default')) %>
+
+  <%# Include the steps %>
+  <%= include('steps/' + (xrd.metadata.annotations?.['backstage.io/steps'] || 'default')) %>
+```
+
+**Can Be Replaced With** (external tools):
+```bash
+# Using jq to generate simple template
+cat xrd.json | jq '
+  .xrd | {
+    apiVersion: "scaffolder.backstage.io/v1beta3",
+    kind: "Template",
+    metadata: {
+      name: .metadata.name,
+      title: .spec.names.kind
+    },
+    spec: {
+      owner: "platform-team",
+      type: "crossplane-resource",
+      parameters: [],
+      steps: []
+    }
+  }
+' > template.yaml
+
+# Using Python script with Jinja2
+python generate-template.py --xrd xrd.json --template my-template.j2
+
+# Using Go template CLI
+gomplate -f template.gotmpl -d xrd=xrd.json -o template.yaml
+```
+
+### 3. Provide Tool (`@openportal/backstage-provider`)
+
+**Purpose**: Backstage-specific plugin to provide templates to the catalog
+
+**Note**: This is primarily a Backstage plugin, not a CLI tool
+
+**Plugin Configuration**:
+```yaml
+# app-config.yaml
+catalog:
+  providers:
+    xrdTemplates:
+      enabled: true
+      sourceDirectory: /app/generated-templates  # Where transform outputs
+      watchForChanges: true
+      schedule:
+        frequency: { minutes: 5 }
+```
+
+**Library Usage** (within Backstage):
+```typescript
+import { XrdTemplateProvider } from '@openportal/backstage-provider';
+
+// In backend plugin
+export default createBackendPlugin({
+  pluginId: 'catalog',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogServiceRef,
+        config: configServiceRef,
+        scheduler: schedulerServiceRef
+      },
+      async init({ catalog, config, scheduler }) {
+        const provider = new XrdTemplateProvider({
+          sourceDirectory: config.getString('catalog.providers.xrdTemplates.sourceDirectory'),
+          schedule: scheduler.createScheduledTaskRunner(/* ... */)
+        });
+
+        catalog.addEntityProvider(provider);
+      }
+    });
+  }
+});
+```
+
+**Can Be Replaced With** (for providing to Backstage):
+```bash
+# Using GitHub Actions to commit templates
+git add generated-templates/
+git commit -m "Update templates"
+git push
+
+# Using curl to register with Backstage API
+curl -X POST http://backstage:7007/api/catalog/locations \
+  -H "Content-Type: application/json" \
+  -d '{"type":"url","target":"https://github.com/org/templates"}'
+
+# Using static catalog configuration
+# In app-config.yaml:
+catalog:
+  locations:
+    - type: file
+      target: /app/generated-templates/**/*.yaml
+```
+
+## Implementation Plan
+
+### Phase 1: Core Libraries (Weeks 1-2)
+1. Create three npm packages
+2. Define interfaces between tools
+3. Implement basic Extract (K8s + files)
+4. Implement Transform with Eta
+5. Implement Provide as Backstage plugin
+
+### Phase 2: Template System (Weeks 3-4)
+1. Design template directory structure
+2. Create default templates
+3. Implement template selection logic
+4. Add helper functions for Eta
+5. Create template documentation
+
+### Phase 3: CLI Tools (Week 5)
+1. Create CLI for Extract
+2. Create CLI for Transform
+3. Add piping support (Unix philosophy)
+4. Add validation commands
+5. Create examples
+
+### Phase 4: Integration (Week 6)
+1. Update existing ingestor to use new libraries
+2. Migration guide
+3. Performance testing
+4. Documentation
+5. Examples repository
+
+## Tool Composition & Unix Philosophy
+
+### Piping Support
+
+The tools support Unix-style piping for composition:
+
+```bash
+# Full pipeline using our tools
+xrd-extract --source kubernetes | xrd-transform --templates ./templates | backstage-provide
+
+# Mix our tools with standard Unix tools
+xrd-extract --source file --path "*.yaml" | \
+  jq '.xrd' | \
+  xrd-transform --templates ./templates | \
+  tee generated.yaml | \
+  wc -l
+
+# Replace middle step with custom script
+xrd-extract --source kubernetes | \
+  python my-transformer.py | \
+  backstage-provide
+```
+
+### Stdin/Stdout Support
+
+Each tool can read from stdin and write to stdout:
+
+```bash
+# Extract reads file, outputs to stdout
+xrd-extract --source file --path xrd.yaml
+
+# Transform reads from stdin, outputs to stdout
+cat xrd.json | xrd-transform --templates ./templates
+
+# Provide reads from stdin (when not used as plugin)
+cat template.yaml | backstage-provide --api-url http://backstage:7007
+```
+
+## Usage Scenarios
+
+### Scenario 1: Development Time
+```bash
+# Extract XRD from file
+xrd-extract --source file --path my-xrd.yaml --output temp/
+
+# Transform with custom templates
+xrd-transform --input temp/my-xrd.json \
+              --templates ./my-templates \
+              --output ./generated/
+
+# Review generated template
+cat ./generated/my-xrd-template.yaml
+```
+
+### Scenario 2: CI/CD Pipeline
+```yaml
+# .github/workflows/generate-templates.yml
+- name: Extract XRDs from cluster
+  run: xrd-extract --source kubernetes --output xrds/
+
+- name: Transform to Backstage templates
+  run: xrd-transform --input xrds/ --templates ./templates --output catalog/
+
+- name: Commit templates
+  run: |
+    git add catalog/
+    git commit -m "Update Backstage templates"
+    git push
+```
+
+### Scenario 3: Kubernetes CronJob
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: xrd-template-generator
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: generator
+            image: openportal/xrd-pipeline:latest
+            command:
+            - sh
+            - -c
+            - |
+              xrd-extract --source kubernetes --output /tmp/xrds/
+              xrd-transform --input /tmp/xrds/ --output /output/
+              # Output mounted as volume shared with Backstage
+```
+
+### Scenario 4: Backstage Embedded
+```yaml
+# Standard Backstage deployment
+# Provider watches directory populated by external process
+catalog:
+  providers:
+    xrdTemplates:
+      sourceDirectory: /shared/templates
+```
+
+## Template Examples
+
+### Simple Backstage Template (`backstage/simple.eta`):
+```eta
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: <%= helpers.slugify(xrd.metadata.name) %>
+  title: <%= xrd.spec.names.kind %>
+spec:
+  owner: platform-team
+  type: crossplane-resource
+  parameters:
+    - title: Resource Configuration
+      properties:
+        name:
+          title: Name
+          type: string
+        <% helpers.extractProperties(xrd).forEach(prop => { %>
+        <%= prop.name %>:
+          title: <%= prop.title %>
+          type: <%= prop.type %>
+        <% }) %>
+  steps:
+    - id: create-resource
+      name: Create <%= xrd.spec.names.kind %>
+      action: kubernetes:apply
+      input:
+        manifest: |
+          apiVersion: <%= xrd.spec.group %>/<%= xrd.spec.versions[0].name %>
+          kind: <%= xrd.spec.names.kind %>
+          metadata:
+            name: ${{ parameters.name }}
+          spec: ${{ parameters }}
+```
+
+### GitOps Wizard (`wizard/gitops.eta`):
+```eta
+parameters:
+  - title: Resource Metadata
+    required:
+      - name
+      - owner
+    properties:
+      name:
+        title: Name
+        type: string
+      owner:
+        title: Owner
+        type: string
+        ui:field: OwnerPicker
+
+  - title: GitOps Configuration
+    properties:
+      repository:
+        title: Target Repository
+        type: string
+        default: catalog-orders
+      branch:
+        title: Target Branch
+        type: string
+        default: main
+      createPR:
+        title: Create Pull Request
+        type: boolean
+        default: true
+
+  - title: Resource Specification
+    properties:
+      <% helpers.extractProperties(xrd).forEach(prop => { %>
+      <%= prop.name %>:
+        title: <%= prop.title %>
+        type: <%= prop.type %>
+        <% if (prop.description) { %>
+        description: <%= prop.description %>
+        <% } %>
+      <% }) %>
+```
+
+## Benefits of This Architecture
+
+1. **Modularity**: Each tool does one thing well
+2. **Flexibility**: Tools can be replaced/combined differently
+3. **Testability**: Each tool can be tested independently
+4. **Customization**: Complete control via templates
+5. **Deployment Options**: Run anywhere (CI, K8s, Backstage)
+6. **Developer Experience**: Simple CLI tools, clear interfaces
+7. **Maintenance**: Smaller, focused codebases
+
+## Next Discussion Points
+
+### Immediate Decisions Needed
+
+1. **Package Naming**:
+   - Option A: `@openportal/xrd-extract`, `@openportal/xrd-transform`, `@openportal/backstage-provider`
+   - Option B: More generic like `@openportal/k8s-resource-extract`, `@openportal/template-engine`, etc.
+
+2. **Template Directory Structure**:
+   - Should we have a standard directory layout that users must follow?
+   - Or allow complete flexibility with configuration?
+
+3. **Error Handling Strategy**:
+   - What happens when a template has an error?
+   - Should we generate a "safe" default or fail completely?
+
+4. **Library vs CLI First**:
+   - Should we build the library first and wrap with CLI?
+   - Or build CLI first and extract library?
+
+### Technical Questions
+
+1. **Template Helpers**: What helper functions do we need in Eta?
+   - `slugify()` - Convert names to valid K8s names
+   - `extractProperties()` - Extract properties from XRD schema
+   - `generateValidation()` - Create validation rules
+   - What else?
+
+2. **Streaming vs Batch**:
+   - Should Extract output one JSON per XRD?
+   - Or batch all XRDs in one JSON array?
+   - How does this affect piping?
+
+3. **Configuration**:
+   - How much should be configurable vs convention?
+   - Environment variables vs config files vs CLI flags?
+
+### Future Considerations
+
+1. **Template Marketplace**:
+   - Should we plan for a template registry/marketplace?
+   - How would templates be shared/discovered?
+
+2. **Validation & Testing**:
+   - How do we validate Eta templates before use?
+   - Should we provide a test framework for templates?
+
+3. **Migration Path**:
+   - How do we migrate from current ingestor?
+   - Can we support both architectures temporarily?
+
+## Summary
+
+This architecture provides:
+- **Clear separation of concerns** with three independent tools
+- **Complete flexibility** through tool replacement (not plugins)
+- **Full template control** via Eta templates with XRD annotations
+- **Multiple deployment options** (embedded, external, CI/CD)
+- **Unix philosophy** with piping and file-based interfaces
+
+The key insight is that by making tools completely independent and communicating via files, we enable maximum flexibility without the complexity of a plugin system. Users can mix and match our tools with their own scripts, existing tools, or completely custom solutions.

--- a/scripts/template-export.sh
+++ b/scripts/template-export.sh
@@ -153,4 +153,4 @@ fi
 
 # Run the export CLI directly from source using ts-node
 cd "$PLUGIN_DIR"
-npx ts-node src/cli/backstage-export-cli.ts "${ARGS[@]}"
+npx ts-node --project tsconfig.cli.json src/cli/backstage-export-cli.ts "${ARGS[@]}"

--- a/scripts/template-ingest.sh
+++ b/scripts/template-ingest.sh
@@ -118,4 +118,4 @@ fi
 # Run the ingestor CLI directly from source using ts-node
 cd "$PLUGIN_DIR"
 # echo "Args: ${ARGS[*]}"
-npx ts-node src/cli/ingestor-cli.ts "${ARGS[@]}"
+npx ts-node --project tsconfig.cli.json src/cli/ingestor-cli.ts "${ARGS[@]}"

--- a/scripts/xrd-transform.sh
+++ b/scripts/xrd-transform.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# XRD Transform - Transform Crossplane XRDs into Backstage templates
+#
+# This script wraps the xrd-transform CLI tool from the ingestor plugin,
+# allowing you to run it from anywhere in the workspace.
+#
+# Usage:
+#   ./scripts/xrd-transform.sh [options] [input]
+#   cat xrd.yaml | ./scripts/xrd-transform.sh [options]
+#
+# Examples:
+#   # Transform from file
+#   ./scripts/xrd-transform.sh template-namespace/configuration/xrd.yaml
+#
+#   # Transform from stdin
+#   cat template-namespace/configuration/xrd.yaml | ./scripts/xrd-transform.sh
+#
+#   # Verbose output
+#   ./scripts/xrd-transform.sh -v template-namespace/configuration/xrd.yaml
+#
+#   # Save to file
+#   ./scripts/xrd-transform.sh template-namespace/configuration/xrd.yaml > output.yaml
+#
+#   # Use custom templates
+#   ./scripts/xrd-transform.sh -t my-templates template-namespace/configuration/xrd.yaml
+#
+# Options:
+#   -t, --templates <dir>    Template directory (defaults to built-in templates)
+#   -o, --output <dir>       Output directory (default: stdout)
+#   -f, --format <format>    Output format (yaml|json) (default: yaml)
+#   --single-file            Output all entities to a single file
+#   --organize               Organize output by entity type
+#   -v, --verbose            Verbose output
+#   --validate               Validate output
+#   --watch                  Watch for changes (when input is directory)
+#   -h, --help               Display help
+#
+
+set -euo pipefail
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLUGIN_DIR="${WORKSPACE_DIR}/app-portal/plugins/ingestor"
+
+# Check if plugin directory exists
+if [[ ! -d "${PLUGIN_DIR}" ]]; then
+    echo "Error: Ingestor plugin not found at ${PLUGIN_DIR}" >&2
+    echo "Please ensure you're running this from the portal-workspace directory" >&2
+    exit 1
+fi
+
+# Change to plugin directory (required for ts-node and template resolution)
+cd "${PLUGIN_DIR}"
+
+# Collect all arguments
+ARGS=()
+for arg in "$@"; do
+    # If argument is a file path and not an option, make it absolute
+    if [[ ! "$arg" =~ ^- ]] && [[ -f "${WORKSPACE_DIR}/${arg}" ]]; then
+        ARGS+=("${WORKSPACE_DIR}/${arg}")
+    else
+        ARGS+=("$arg")
+    fi
+done
+
+# Run the CLI via ts-node
+npx ts-node --project tsconfig.cli.json \
+    src/xrd-transform/cli/xrd-transform-cli.ts \
+    "${ARGS[@]}"

--- a/templates-old/cloudflarednsrecord-openportal.dev--v1alpha1-api.yaml
+++ b/templates-old/cloudflarednsrecord-openportal.dev--v1alpha1-api.yaml
@@ -1,0 +1,344 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+  name: cloudflarednsrecord-openportal.dev--v1alpha1
+  title: cloudflarednsrecord-openportal.dev--v1alpha1
+  uid: 0e4b621f-baf8-4d6f-9933-c2540ab65b70
+  etag: dab605e6763dcd3e59bf08cfcbc28731314b6f31
+apiVersion: backstage.io/v1alpha1
+kind: API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: kubernetes-auto-ingested
+  system: kubernets-auto-ingested
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: cloudflarednsrecords.openportal.dev
+      version: v1alpha1
+    servers:
+      - url: https://hcp-ebadc4bb-307d-482e-a9d9-fdca15fd5ff1.spot.rackspace.com/
+        description: openportal
+    tags:
+      - name: Cluster Scoped Operations
+        description: Operations on the cluster level
+      - name: Namespace Scoped Operations
+        description: Operations on the namespace level
+      - name: Specific Object Scoped Operations
+        description: Operations on a specific resource
+    paths:
+      /apis/openportal.dev/v1alpha1/cloudflarednsrecords:
+        get:
+          tags:
+            - Cluster Scoped Operations
+          summary: List all cloudflarednsrecords in all namespaces
+          operationId: listcloudflarednsrecordsAllNamespaces
+          responses:
+            '200':
+              description: List of cloudflarednsrecords in all namespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/cloudflarednsrecords:
+        get:
+          tags:
+            - Namespace Scoped Operations
+          summary: List all cloudflarednsrecords in a namespace
+          operationId: listcloudflarednsrecords
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: List of cloudflarednsrecords
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+        post:
+          tags:
+            - Namespace Scoped Operations
+          summary: Create a resource
+          operationId: createResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '201':
+              description: Resource created
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/cloudflarednsrecords/{name}:
+        get:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Get a CloudflareDNSRecord
+          operationId: getCloudflareDNSRecord
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource details
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    $ref: '#/components/schemas/Resource'
+        put:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Update a resource
+          operationId: updateResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '200':
+              description: Resource updated
+        delete:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Delete a resource
+          operationId: deleteResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource deleted
+    components:
+      schemas:
+        Resource:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              required:
+                - type
+                - name
+                - value
+              properties:
+                comment:
+                  description: Optional comment for the DNS record
+                  type: string
+                  maxLength: 100
+                crossplane:
+                  description: Configures how Crossplane will reconcile this composite resource
+                  type: object
+                  properties:
+                    compositionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionUpdatePolicy:
+                      type: string
+                      default: Automatic
+                      enum:
+                        - Automatic
+                        - Manual
+                    resourceRefs:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - apiVersion
+                          - kind
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                      x-kubernetes-list-type: atomic
+                name:
+                  description: >-
+                    Subdomain name (e.g., 'api' creates api.yourdomain.com, use '@'
+                    for root domain)
+                  type: string
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(@)?$
+                priority:
+                  description: Priority for MX and SRV records
+                  type: integer
+                  maximum: 65535
+                  minimum: 0
+                proxied:
+                  description: Whether to use Cloudflare proxy (orange cloud)
+                  type: boolean
+                  default: false
+                ttl:
+                  description: Time to live in seconds (1 = automatic)
+                  type: integer
+                  default: 1
+                  maximum: 86400
+                  minimum: 1
+                type:
+                  description: DNS record type
+                  type: string
+                  enum:
+                    - A
+                    - AAAA
+                    - CNAME
+                    - TXT
+                    - MX
+                    - NS
+                    - SRV
+                value:
+                  description: >-
+                    Target value: IPv4 for A, IPv6 for AAAA, hostname for CNAME,
+                    text for TXT
+                  type: string
+                zone:
+                  description: >-
+                    Cloudflare Zone resource (leave default for openportal.dev
+                    domain)
+                  type: string
+                  default: openportal-zone
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: Conditions of the resource.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                fqdn:
+                  description: Fully qualified domain name
+                  type: string
+                ready:
+                  description: Whether the record is ready
+                  type: boolean
+                recordId:
+                  description: Cloudflare record ID
+                  type: string
+      securitySchemes:
+        bearerHttpAuthentication:
+          description: Bearer token using a JWT
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+    security:
+      - bearerHttpAuthentication: []
+relations:
+  - type: apiConsumedBy
+    targetRef: component:demo/whoami-demo-dns-openportal
+  - type: apiConsumedBy
+    targetRef: component:test/whoami-dns-openportal
+  - type: ownedBy
+    targetRef: group:default/kubernetes-auto-ingested
+  - type: partOf
+    targetRef: system:default/kubernets-auto-ingested

--- a/templates-old/cloudflarednsrecords.openportal.dev-v1alpha1-template.yaml
+++ b/templates-old/cloudflarednsrecords.openportal.dev-v1alpha1-template.yaml
@@ -1,0 +1,309 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+    terasky.backstage.io/crossplane-version: v2
+    terasky.backstage.io/crossplane-scope: Namespaced
+    backstage.io/description: Create and manage DNS records in Cloudflare with automatic zone configuration
+    backstage.io/source-location: url:https://github.com/open-service-portal/template-cloudflare-dnsrecord
+    backstage.io/title: Cloudflare DNS Record
+    crossplane.io/version: v2.0
+    description: Manage real DNS records in Cloudflare
+    github.com/project-slug: open-service-portal/template-cloudflare-dnsrecord
+    openportal.dev/tags: dns,cloudflare
+    terasky.backstage.io/add-to-catalog: 'true'
+    terasky.backstage.io/auto-apply: 'true'
+    terasky.backstage.io/component-type: crossplane-template
+    terasky.backstage.io/composition-strategy: direct
+    terasky.backstage.io/default-composition: cloudflarednsrecord
+    terasky.backstage.io/lifecycle: production
+    terasky.backstage.io/owner: platform-team
+    terasky.backstage.io/skip-publish-step: 'true'
+    terasky.backstage.io/system: infrastructure-templates
+    terasky.backstage.io/tags: dns,cloudflare
+    backstage.io/discovered-at: '2025-09-10T08:56:44.167Z'
+  name: cloudflarednsrecords.openportal.dev-v1alpha1
+  title: CloudflareDNSRecord
+  description: A template to create a cloudflarednsrecords.openportal.dev instance
+  labels:
+    forEntity: system
+    source: crossplane
+    openportal.dev/version: v2.0.2
+    terasky.backstage.io/generate-form: 'true'
+  tags:
+    - source:kubernetes-ingestor
+    - crossplane
+    - cluster:openportal
+  uid: 9b6a210a-b38e-4045-87a3-691875823467
+  etag: 7138c2f11988ee9b09c25cccef2b3fa79761bd48
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  type: cloudflarednsrecords.openportal.dev
+  parameters:
+    - title: Resource Metadata
+      required:
+        - xrName
+        - owner
+        - xrNamespace
+      properties:
+        xrName:
+          title: Name
+          description: The name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+        xrNamespace:
+          title: Namespace
+          description: 'The namespace in which to create the resource (default: demo)'
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+          default: demo
+        owner:
+          title: Owner
+          description: The owner of the resource
+          type: string
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+      type: object
+    - title: Resource Spec
+      properties:
+        comment:
+          description: Optional comment for the DNS record
+          maxLength: 100
+          type: string
+        name:
+          description: Subdomain name (e.g., 'api' creates api.yourdomain.com, use '@' for root domain)
+          examples:
+            - api
+            - www
+            - staging
+            - '@'
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(@)?$
+          type: string
+        priority:
+          description: Priority for MX and SRV records
+          maximum: 65535
+          minimum: 0
+          type: integer
+        proxied:
+          default: false
+          description: Whether to use Cloudflare proxy (orange cloud)
+          type: boolean
+        ttl:
+          description: Time to live in seconds (1 = automatic)
+          maximum: 86400
+          minimum: 1
+          type: integer
+          ui:placeholder: 1
+        type:
+          description: DNS record type
+          enum:
+            - A
+            - AAAA
+            - CNAME
+            - TXT
+            - MX
+            - NS
+            - SRV
+          type: string
+        value:
+          description: 'Target value: IPv4 for A, IPv6 for AAAA, hostname for CNAME, text for TXT'
+          examples:
+            - 192.168.1.100
+            - 2001:db8::1
+            - target.example.com
+          type: string
+        zone:
+          description: Cloudflare Zone resource (leave default for openportal.dev domain)
+          type: string
+          ui:placeholder: openportal-zone
+      type: object
+    - title: Crossplane Settings
+      properties:
+        crossplane:
+          title: Crossplane Configuration
+          type: object
+          properties:
+            compositionUpdatePolicy:
+              title: Composition Update Policy
+              enum:
+                - Automatic
+                - Manual
+              type: string
+            compositionSelectionStrategy:
+              title: Composition Selection Strategy
+              description: How the composition should be selected.
+              enum:
+                - runtime
+                - direct-reference
+                - label-selector
+              default: runtime
+              type: string
+          dependencies:
+            compositionSelectionStrategy:
+              oneOf:
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - runtime
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - direct-reference
+                    compositionRef:
+                      title: Composition Reference
+                      properties:
+                        name:
+                          type: string
+                          title: Select A Composition By Name
+                          enum:
+                            - cloudflarednsrecord
+                          default: cloudflarednsrecord
+                      required:
+                        - name
+                      type: object
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - label-selector
+                    compositionSelector:
+                      title: Composition Selector
+                      properties:
+                        matchLabels:
+                          title: Match Labels
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                        - matchLabels
+                      type: object
+      type: object
+    - title: Creation Settings
+      properties:
+        pushToGit:
+          title: Push Manifest to GitOps Repository
+          type: boolean
+          default: true
+      dependencies:
+        pushToGit:
+          oneOf:
+            - properties:
+                pushToGit:
+                  enum:
+                    - false
+            - properties:
+                pushToGit:
+                  enum:
+                    - true
+                manifestLayout:
+                  type: string
+                  description: Layout of the manifest
+                  default: cluster-scoped
+                  ui:help: |-
+                    Choose how the manifest should be generated in the repo.
+                    * Cluster-scoped - a manifest is created for each selected cluster under the root directory of the clusters name
+                    * namespace-scoped - a manifest is created for the resource under the root directory with the namespace name
+                    * custom - a manifest is created under the specified base path
+                  enum:
+                    - cluster-scoped
+                    - namespace-scoped
+                    - custom
+              dependencies:
+                manifestLayout:
+                  oneOf:
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - cluster-scoped
+                        clusters:
+                          title: Target Clusters
+                          description: The target clusters to apply the resource to
+                          type: array
+                          minItems: 1
+                          items:
+                            enum:
+                              - openportal
+                            type: string
+                          uniqueItems: true
+                          ui:widget: checkboxes
+                      required:
+                        - clusters
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - custom
+                        basePath:
+                          type: string
+                          description: Base path in GitOps repository to push the manifest to
+                      required:
+                        - basePath
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - namespace-scoped
+  steps:
+    - id: generateManifest
+      name: Generate Kubernetes Resource Manifest
+      action: terasky:claim-template
+      input:
+        parameters: ${{ parameters }}
+        nameParam: xrName
+        namespaceParam: xrNamespace
+        ownerParam: owner
+        excludeParams:
+          - crossplane.compositionSelectionStrategy
+          - owner
+          - pushToGit
+          - basePath
+          - manifestLayout
+          - _editData
+          - targetBranch
+          - repoUrl
+          - clusters
+          - xrName
+          - xrNamespace
+        apiVersion: openportal.dev/v1alpha1
+        kind: CloudflareDNSRecord
+        clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}
+        removeEmptyParams: true
+    - id: moveNamespacedManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'namespace-scoped' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.xrNamespace }}/${{ steps.generateManifest.input.kind }}/${{ steps.generateManifest.output.filePaths[0].split('/').pop() }}
+    - id: moveCustomManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'custom' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.basePath }}/${{ parameters.xrName }}.yaml
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      if: ${{ parameters.pushToGit }}
+      input:
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
+        branchName: create-${{ parameters.xrName }}-resource
+        title: Create CloudflareDNSRecord Resource ${{ parameters.xrName }}
+        description: Create CloudflareDNSRecord Resource ${{ parameters.xrName }}
+        targetBranchName: main
+  output:
+    links:
+      - title: Download YAML Manifest
+        url: data:application/yaml;charset=utf-8,${{ steps.generateManifest.output.manifest }}
+      - title: Open Pull Request
+        if: ${{ parameters.pushToGit }}
+        url: ${{ steps["create-pull-request"].output.remoteUrl }}
+relations: []

--- a/templates-old/dnsrecord-openportal.dev--v1alpha1-api.yaml
+++ b/templates-old/dnsrecord-openportal.dev--v1alpha1-api.yaml
@@ -1,0 +1,312 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+  name: dnsrecord-openportal.dev--v1alpha1
+  title: dnsrecord-openportal.dev--v1alpha1
+  uid: 882668b1-ef12-4f41-b1b8-16897cf7e7b8
+  etag: 08a3e6cb33f16f6ef44eb306a9bc4bb70a48a1ea
+apiVersion: backstage.io/v1alpha1
+kind: API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: kubernetes-auto-ingested
+  system: kubernets-auto-ingested
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: dnsrecords.openportal.dev
+      version: v1alpha1
+    servers:
+      - url: https://hcp-ebadc4bb-307d-482e-a9d9-fdca15fd5ff1.spot.rackspace.com/
+        description: openportal
+    tags:
+      - name: Cluster Scoped Operations
+        description: Operations on the cluster level
+      - name: Namespace Scoped Operations
+        description: Operations on the namespace level
+      - name: Specific Object Scoped Operations
+        description: Operations on a specific resource
+    paths:
+      /apis/openportal.dev/v1alpha1/dnsrecords:
+        get:
+          tags:
+            - Cluster Scoped Operations
+          summary: List all dnsrecords in all namespaces
+          operationId: listdnsrecordsAllNamespaces
+          responses:
+            '200':
+              description: List of dnsrecords in all namespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/dnsrecords:
+        get:
+          tags:
+            - Namespace Scoped Operations
+          summary: List all dnsrecords in a namespace
+          operationId: listdnsrecords
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: List of dnsrecords
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+        post:
+          tags:
+            - Namespace Scoped Operations
+          summary: Create a resource
+          operationId: createResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '201':
+              description: Resource created
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/dnsrecords/{name}:
+        get:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Get a DNSRecord
+          operationId: getDNSRecord
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource details
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    $ref: '#/components/schemas/Resource'
+        put:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Update a resource
+          operationId: updateResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '200':
+              description: Resource updated
+        delete:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Delete a resource
+          operationId: deleteResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource deleted
+    components:
+      schemas:
+        Resource:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              required:
+                - type
+                - name
+                - value
+              properties:
+                crossplane:
+                  description: Configures how Crossplane will reconcile this composite resource
+                  type: object
+                  properties:
+                    compositionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionUpdatePolicy:
+                      type: string
+                      default: Automatic
+                      enum:
+                        - Automatic
+                        - Manual
+                    resourceRefs:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - apiVersion
+                          - kind
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                      x-kubernetes-list-type: atomic
+                name:
+                  description: DNS record name (subdomain)
+                  type: string
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?(\.[a-z]([-a-z0-9]*[a-z0-9])?)*$
+                  example: my-app
+                ttl:
+                  description: Time to live in seconds
+                  type: integer
+                  default: 300
+                  maximum: 86400
+                  minimum: 60
+                type:
+                  description: DNS record type
+                  type: string
+                  enum:
+                    - A
+                    - AAAA
+                    - CNAME
+                    - TXT
+                  example: A
+                value:
+                  description: DNS record value (IP address, hostname, or text)
+                  type: string
+                  example: 192.168.1.100
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: Conditions of the resource.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                fqdn:
+                  description: Fully qualified domain name
+                  type: string
+                  example: my-app.portal.example.com
+      securitySchemes:
+        bearerHttpAuthentication:
+          description: Bearer token using a JWT
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+    security:
+      - bearerHttpAuthentication: []
+relations:
+  - type: ownedBy
+    targetRef: group:default/kubernetes-auto-ingested
+  - type: partOf
+    targetRef: system:default/kubernets-auto-ingested

--- a/templates-old/dnsrecords.openportal.dev-v1alpha1-template.yaml
+++ b/templates-old/dnsrecords.openportal.dev-v1alpha1-template.yaml
@@ -1,0 +1,269 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+    terasky.backstage.io/crossplane-version: v2
+    terasky.backstage.io/crossplane-scope: Namespaced
+    backstage.io/source-location: url:https://github.com/open-service-portal/template-dns-record
+    crossplane.io/version: v2.0
+    openportal.dev/tags: dns,mock
+    backstage.io/discovered-at: '2025-09-10T08:56:44.167Z'
+  name: dnsrecords.openportal.dev-v1alpha1
+  title: DNSRecord
+  description: A template to create a dnsrecords.openportal.dev instance
+  labels:
+    forEntity: system
+    source: crossplane
+    openportal.dev/version: v1.0.8
+    terasky.backstage.io/generate-form: 'true'
+    terasky.backstage.io/version: v1.0.4
+  tags:
+    - source:kubernetes-ingestor
+    - crossplane
+    - cluster:openportal
+  uid: 054b4c5e-5840-4409-a6eb-7b91e9893e1b
+  etag: 92812acd1bb1c4ae3091135e909a8d9a9ce9dd00
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  type: dnsrecords.openportal.dev
+  parameters:
+    - title: Resource Metadata
+      required:
+        - xrName
+        - owner
+        - xrNamespace
+      properties:
+        xrName:
+          title: Name
+          description: The name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+        xrNamespace:
+          title: Namespace
+          description: 'The namespace in which to create the resource (default: demo)'
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+          default: demo
+        owner:
+          title: Owner
+          description: The owner of the resource
+          type: string
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+      type: object
+    - title: Resource Spec
+      properties:
+        name:
+          description: DNS record name (subdomain)
+          example: my-app
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?(\.[a-z]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+        ttl:
+          description: Time to live in seconds
+          maximum: 86400
+          minimum: 60
+          type: integer
+          ui:placeholder: 300
+        type:
+          description: DNS record type
+          enum:
+            - A
+            - AAAA
+            - CNAME
+            - TXT
+          example: A
+          type: string
+        value:
+          description: DNS record value (IP address, hostname, or text)
+          example: 192.168.1.100
+          type: string
+      type: object
+    - title: Crossplane Settings
+      properties:
+        crossplane:
+          title: Crossplane Configuration
+          type: object
+          properties:
+            compositionUpdatePolicy:
+              title: Composition Update Policy
+              enum:
+                - Automatic
+                - Manual
+              type: string
+            compositionSelectionStrategy:
+              title: Composition Selection Strategy
+              description: How the composition should be selected.
+              enum:
+                - runtime
+                - direct-reference
+                - label-selector
+              default: runtime
+              type: string
+          dependencies:
+            compositionSelectionStrategy:
+              oneOf:
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - runtime
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - direct-reference
+                    compositionRef:
+                      title: Composition Reference
+                      properties:
+                        name:
+                          type: string
+                          title: Select A Composition By Name
+                          enum:
+                            - dnsrecord
+                      required:
+                        - name
+                      type: object
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - label-selector
+                    compositionSelector:
+                      title: Composition Selector
+                      properties:
+                        matchLabels:
+                          title: Match Labels
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                        - matchLabels
+                      type: object
+      type: object
+    - title: Creation Settings
+      properties:
+        pushToGit:
+          title: Push Manifest to GitOps Repository
+          type: boolean
+          default: true
+      dependencies:
+        pushToGit:
+          oneOf:
+            - properties:
+                pushToGit:
+                  enum:
+                    - false
+            - properties:
+                pushToGit:
+                  enum:
+                    - true
+                manifestLayout:
+                  type: string
+                  description: Layout of the manifest
+                  default: cluster-scoped
+                  ui:help: |-
+                    Choose how the manifest should be generated in the repo.
+                    * Cluster-scoped - a manifest is created for each selected cluster under the root directory of the clusters name
+                    * namespace-scoped - a manifest is created for the resource under the root directory with the namespace name
+                    * custom - a manifest is created under the specified base path
+                  enum:
+                    - cluster-scoped
+                    - namespace-scoped
+                    - custom
+              dependencies:
+                manifestLayout:
+                  oneOf:
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - cluster-scoped
+                        clusters:
+                          title: Target Clusters
+                          description: The target clusters to apply the resource to
+                          type: array
+                          minItems: 1
+                          items:
+                            enum:
+                              - openportal
+                            type: string
+                          uniqueItems: true
+                          ui:widget: checkboxes
+                      required:
+                        - clusters
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - custom
+                        basePath:
+                          type: string
+                          description: Base path in GitOps repository to push the manifest to
+                      required:
+                        - basePath
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - namespace-scoped
+  steps:
+    - id: generateManifest
+      name: Generate Kubernetes Resource Manifest
+      action: terasky:claim-template
+      input:
+        parameters: ${{ parameters }}
+        nameParam: xrName
+        namespaceParam: xrNamespace
+        ownerParam: owner
+        excludeParams:
+          - crossplane.compositionSelectionStrategy
+          - owner
+          - pushToGit
+          - basePath
+          - manifestLayout
+          - _editData
+          - targetBranch
+          - repoUrl
+          - clusters
+          - xrName
+          - xrNamespace
+        apiVersion: openportal.dev/v1alpha1
+        kind: DNSRecord
+        clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}
+        removeEmptyParams: true
+    - id: moveNamespacedManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'namespace-scoped' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.xrNamespace }}/${{ steps.generateManifest.input.kind }}/${{ steps.generateManifest.output.filePaths[0].split('/').pop() }}
+    - id: moveCustomManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'custom' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.basePath }}/${{ parameters.xrName }}.yaml
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      if: ${{ parameters.pushToGit }}
+      input:
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
+        branchName: create-${{ parameters.xrName }}-resource
+        title: Create DNSRecord Resource ${{ parameters.xrName }}
+        description: Create DNSRecord Resource ${{ parameters.xrName }}
+        targetBranchName: main
+  output:
+    links:
+      - title: Download YAML Manifest
+        url: data:application/yaml;charset=utf-8,${{ steps.generateManifest.output.manifest }}
+      - title: Open Pull Request
+        if: ${{ parameters.pushToGit }}
+        url: ${{ steps["create-pull-request"].output.remoteUrl }}
+relations: []

--- a/templates-old/managednamespace-openportal.dev--v1alpha1-api.yaml
+++ b/templates-old/managednamespace-openportal.dev--v1alpha1-api.yaml
@@ -1,0 +1,300 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+  name: managednamespace-openportal.dev--v1alpha1
+  title: managednamespace-openportal.dev--v1alpha1
+  uid: 77130470-d64d-4b14-8567-8a77196cab13
+  etag: d80bae65d056d03fcc286421cf236eaf56d10bbb
+apiVersion: backstage.io/v1alpha1
+kind: API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: kubernetes-auto-ingested
+  system: kubernets-auto-ingested
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: managednamespaces.openportal.dev
+      version: v1alpha1
+    servers:
+      - url: https://hcp-ebadc4bb-307d-482e-a9d9-fdca15fd5ff1.spot.rackspace.com/
+        description: openportal
+    tags:
+      - name: Cluster Scoped Operations
+        description: Operations on the cluster level
+      - name: Namespace Scoped Operations
+        description: Operations on the namespace level
+      - name: Specific Object Scoped Operations
+        description: Operations on a specific resource
+    paths:
+      /apis/openportal.dev/v1alpha1/managednamespaces:
+        get:
+          tags:
+            - Cluster Scoped Operations
+          summary: List all managednamespaces in all namespaces
+          operationId: listmanagednamespacesAllNamespaces
+          responses:
+            '200':
+              description: List of managednamespaces in all namespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/managednamespaces:
+        get:
+          tags:
+            - Namespace Scoped Operations
+          summary: List all managednamespaces in a namespace
+          operationId: listmanagednamespaces
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: List of managednamespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+        post:
+          tags:
+            - Namespace Scoped Operations
+          summary: Create a resource
+          operationId: createResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '201':
+              description: Resource created
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/managednamespaces/{name}:
+        get:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Get a ManagedNamespace
+          operationId: getManagedNamespace
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource details
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    $ref: '#/components/schemas/Resource'
+        put:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Update a resource
+          operationId: updateResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '200':
+              description: Resource updated
+        delete:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Delete a resource
+          operationId: deleteResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource deleted
+    components:
+      schemas:
+        Resource:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              description: Namespace configuration
+              type: object
+              required:
+                - name
+              properties:
+                crossplane:
+                  description: Configures how Crossplane will reconcile this composite resource
+                  type: object
+                  properties:
+                    compositionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionUpdatePolicy:
+                      type: string
+                      default: Automatic
+                      enum:
+                        - Automatic
+                        - Manual
+                    resourceRefs:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - apiVersion
+                          - kind
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                      x-kubernetes-list-type: atomic
+                name:
+                  description: Name of the namespace to create
+                  type: string
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: Conditions of the resource.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                message:
+                  description: Status message
+                  type: string
+                phase:
+                  description: Current phase of the namespace
+                  type: string
+                ready:
+                  description: Whether the namespace is ready
+                  type: boolean
+      securitySchemes:
+        bearerHttpAuthentication:
+          description: Bearer token using a JWT
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+    security:
+      - bearerHttpAuthentication: []
+relations:
+  - type: apiConsumedBy
+    targetRef: component:default/test-namespace-openportal
+  - type: ownedBy
+    targetRef: group:default/kubernetes-auto-ingested
+  - type: partOf
+    targetRef: system:default/kubernets-auto-ingested

--- a/templates-old/managednamespaces.openportal.dev-v1alpha1-template.yaml
+++ b/templates-old/managednamespaces.openportal.dev-v1alpha1-template.yaml
@@ -1,0 +1,241 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+    terasky.backstage.io/crossplane-version: v2
+    terasky.backstage.io/crossplane-scope: Cluster
+    backstage.io/description: Crossplane template for managing Kubernetes namespaces with automated RBAC and resource quotas
+    backstage.io/source-location: url:https://github.com/open-service-portal/template-namespace
+    backstage.io/techdocs-ref: url:https://github.com/open-service-portal/template-namespace
+    backstage.io/title: ManagedNamespace Template
+    crossplane.io/version: v2.0
+    openportal.dev/tags: namespace,kubernetes,core,rbac,infrastructure,platform
+    terasky.backstage.io/publish-phase: |
+      gitRepo: "github.com?owner=open-service-portal&repo=catalog-orders"
+      gitBranch: "main"
+      gitLayout: "cluster-scoped"
+      basePath: "system/ManagedNamespace"
+      createPr: true
+    backstage.io/discovered-at: '2025-09-10T08:56:44.167Z'
+  name: managednamespaces.openportal.dev-v1alpha1
+  title: ManagedNamespace
+  description: A template to create a managednamespaces.openportal.dev instance
+  labels:
+    forEntity: system
+    source: crossplane
+    openportal.dev/version: v3.2.0
+    terasky.backstage.io/generate-form: 'true'
+  tags:
+    - source:kubernetes-ingestor
+    - crossplane
+    - cluster:openportal
+  uid: 6e9b723e-6f47-4e1d-8fca-da86dc556742
+  etag: a077591d911ead94d1c3865e7365d5637fcb0943
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  type: managednamespaces.openportal.dev
+  parameters:
+    - title: Resource Metadata
+      required:
+        - xrName
+        - owner
+      properties:
+        xrName:
+          title: Name
+          description: The name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+        owner:
+          title: Owner
+          description: The owner of the resource
+          type: string
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+      type: object
+    - title: Resource Spec
+      properties:
+        name:
+          description: Name of the namespace to create
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          type: string
+      type: object
+    - title: Crossplane Settings
+      properties:
+        crossplane:
+          title: Crossplane Configuration
+          type: object
+          properties:
+            compositionUpdatePolicy:
+              title: Composition Update Policy
+              enum:
+                - Automatic
+                - Manual
+              type: string
+            compositionSelectionStrategy:
+              title: Composition Selection Strategy
+              description: How the composition should be selected.
+              enum:
+                - runtime
+                - direct-reference
+                - label-selector
+              default: runtime
+              type: string
+          dependencies:
+            compositionSelectionStrategy:
+              oneOf:
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - runtime
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - direct-reference
+                    compositionRef:
+                      title: Composition Reference
+                      properties:
+                        name:
+                          type: string
+                          title: Select A Composition By Name
+                          enum:
+                            - managednamespaces
+                          default: managednamespaces
+                      required:
+                        - name
+                      type: object
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - label-selector
+                    compositionSelector:
+                      title: Composition Selector
+                      properties:
+                        matchLabels:
+                          title: Match Labels
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                        - matchLabels
+                      type: object
+      type: object
+    - title: Creation Settings
+      properties:
+        pushToGit:
+          title: Push Manifest to GitOps Repository
+          type: boolean
+          default: true
+      dependencies:
+        pushToGit:
+          oneOf:
+            - properties:
+                pushToGit:
+                  enum:
+                    - false
+            - properties:
+                pushToGit:
+                  enum:
+                    - true
+                manifestLayout:
+                  type: string
+                  description: Layout of the manifest
+                  default: cluster-scoped
+                  ui:help: |-
+                    Choose how the manifest should be generated in the repo.
+                    * Cluster-scoped - a manifest is created for each selected cluster under the root directory of the clusters name
+                    * namespace-scoped - a manifest is created for the resource under the root directory with the namespace name
+                    * custom - a manifest is created under the specified base path
+                  enum:
+                    - cluster-scoped
+                    - namespace-scoped
+                    - custom
+              dependencies:
+                manifestLayout:
+                  oneOf:
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - cluster-scoped
+                        clusters:
+                          title: Target Clusters
+                          description: The target clusters to apply the resource to
+                          type: array
+                          minItems: 1
+                          items:
+                            enum:
+                              - openportal
+                            type: string
+                          uniqueItems: true
+                          ui:widget: checkboxes
+                      required:
+                        - clusters
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - custom
+                        basePath:
+                          type: string
+                          description: Base path in GitOps repository to push the manifest to
+                      required:
+                        - basePath
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - namespace-scoped
+  steps:
+    - id: generateManifest
+      name: Generate Kubernetes Resource Manifest
+      action: terasky:claim-template
+      input:
+        parameters: ${{ parameters }}
+        nameParam: xrName
+        namespaceParam: ''
+        ownerParam: owner
+        excludeParams:
+          - crossplane.compositionSelectionStrategy
+          - owner
+          - pushToGit
+          - basePath
+          - manifestLayout
+          - _editData
+          - targetBranch
+          - repoUrl
+          - clusters
+          - xrName
+        apiVersion: openportal.dev/v1alpha1
+        kind: ManagedNamespace
+        clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}
+        removeEmptyParams: true
+    - id: moveCustomManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'custom' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.basePath }}/${{ parameters.xrName }}.yaml
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      if: ${{ parameters.pushToGit }}
+      input:
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
+        branchName: create-${{ parameters.xrName }}-resource
+        title: Create ManagedNamespace Resource ${{ parameters.xrName }}
+        description: Create ManagedNamespace Resource ${{ parameters.xrName }}
+        targetBranchName: main
+  output:
+    links:
+      - title: Download YAML Manifest
+        url: data:application/yaml;charset=utf-8,${{ steps.generateManifest.output.manifest }}
+      - title: Open Pull Request
+        if: ${{ parameters.pushToGit }}
+        url: ${{ steps["create-pull-request"].output.remoteUrl }}
+relations: []

--- a/templates-old/service-cluster-template-template.yaml
+++ b/templates-old/service-cluster-template-template.yaml
@@ -1,0 +1,163 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-cluster-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-cluster-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-cluster-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-cluster-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-cluster-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.052Z'
+  name: service-cluster-template
+  title: Kubernetes Cluster
+  description: Provision a Kubernetes cluster using Crossplane
+  tags:
+    - source:github-import
+    - crossplane
+    - kubernetes
+    - cluster
+    - infrastructure
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: b773f382-6de2-4a24-b8e9-642ebc2f2456
+  etag: 9bcbef02c368815a4e84f9f202fbe6b5b4ab173a
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: resource
+  parameters:
+    - title: Cluster Configuration
+      required:
+        - name
+        - version
+      properties:
+        name:
+          title: Cluster Name
+          type: string
+          description: Unique name for your Kubernetes cluster
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          ui:autofocus: true
+        namespace:
+          title: Namespace
+          type: string
+          description: Kubernetes namespace for the cluster resources
+          default: default
+        nodeSize:
+          title: Node Size
+          type: string
+          description: Size of cluster nodes
+          default: medium
+          enum:
+            - small
+            - medium
+            - large
+          enumNames:
+            - Small (2 vCPU, 4GB RAM)
+            - Medium (4 vCPU, 8GB RAM)
+            - Large (8 vCPU, 16GB RAM)
+        nodeCount:
+          title: Node Count
+          type: integer
+          description: Number of nodes in the cluster
+          default: 3
+          minimum: 3
+          maximum: 100
+        storageSize:
+          title: Storage Size (GB)
+          type: integer
+          description: Storage size per node in GB
+          default: 10
+          minimum: 1
+          maximum: 100
+        version:
+          title: Kubernetes Version
+          type: string
+          description: Kubernetes version to deploy
+          default: 1.31.1
+          enum:
+            - 1.31.1
+            - 1.30.5
+            - 1.29.9
+            - 1.29.4
+            - 1.29.2
+            - 1.29.1
+            - 1.29.0
+            - 1.28.14
+            - 1.28.9
+        cloudProvider:
+          title: Cloud Provider
+          type: string
+          description: Cloud provider for the cluster
+          default: azure
+          enum:
+            - aws
+            - azure
+            - gcp
+            - onprem
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the cluster
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+    - title: Repository Location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - open-service-portal
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          nodeSize: ${{ parameters.nodeSize }}
+          nodeCount: ${{ parameters.nodeCount }}
+          storageSize: ${{ parameters.storageSize }}
+          version: ${{ parameters.version }}
+          cloudProvider: ${{ parameters.cloudProvider }}
+          owner: ${{ parameters.owner }}
+          repoUrl: ${{ parameters.repoUrl }}
+    - id: publish
+      name: Publish to GitHub
+      action: publish:github
+      input:
+        description: Kubernetes cluster configuration for ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+        gitCommitMessage: 'feat: add Kubernetes cluster ${{ parameters.name }}'
+        topics:
+          - crossplane
+          - kubernetes
+          - infrastructure
+    - id: register
+      name: Register in Catalog
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/service-dnsrecord-template-template.yaml
+++ b/templates-old/service-dnsrecord-template-template.yaml
@@ -1,0 +1,143 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-dnsrecord-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-dnsrecord-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-dnsrecord-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-dnsrecord-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-dnsrecord-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.092Z'
+  name: service-dnsrecord-template
+  title: DNS Record
+  description: Create and manage DNS records using Crossplane
+  tags:
+    - source:github-import
+    - crossplane
+    - dns
+    - infrastructure
+    - networking
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: 34979462-aeeb-4d30-a393-52725ac1b9ea
+  etag: a2099c0d05119ab19e86f9e0e947c5b7279878de
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: resource
+  parameters:
+    - title: DNS Record Configuration
+      required:
+        - name
+        - dnsName
+        - recordValue
+      properties:
+        name:
+          title: Resource Name
+          type: string
+          description: Unique name for this DNS record resource
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          ui:autofocus: true
+        namespace:
+          title: Namespace
+          type: string
+          description: Kubernetes namespace for the DNS record resource
+          default: default
+        recordType:
+          title: Record Type
+          type: string
+          description: Type of DNS record
+          default: A
+          enum:
+            - A
+            - AAAA
+            - CNAME
+            - TXT
+          enumNames:
+            - A (IPv4 address)
+            - AAAA (IPv6 address)
+            - CNAME (Canonical name)
+            - TXT (Text record)
+        dnsName:
+          title: DNS Name
+          type: string
+          description: The DNS hostname (without domain suffix)
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?(\.[a-z]([-a-z0-9]*[a-z0-9])?)?$
+          examples:
+            - app
+            - api.staging
+            - www
+        recordValue:
+          title: Record Value
+          type: string
+          description: The value for the DNS record (IP address, hostname, or text)
+          examples:
+            - 192.168.1.1
+            - 2001:db8::1
+            - app.example.com
+            - v=spf1 include:_spf.example.com ~all
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the DNS record
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+    - title: Repository Location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - open-service-portal
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          recordType: ${{ parameters.recordType }}
+          dnsName: ${{ parameters.dnsName }}
+          recordValue: ${{ parameters.recordValue }}
+          owner: ${{ parameters.owner }}
+          repoUrl: ${{ parameters.repoUrl }}
+    - id: publish
+      name: Publish to GitHub
+      action: publish:github
+      input:
+        description: DNS record configuration for ${{ parameters.dnsName }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+        gitCommitMessage: 'feat: add DNS record ${{ parameters.dnsName }}'
+        topics:
+          - crossplane
+          - dns
+          - infrastructure
+    - id: register
+      name: Register in Catalog
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/service-firewall-template-template.yaml
+++ b/templates-old/service-firewall-template-template.yaml
@@ -1,0 +1,157 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-firewall-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-firewall-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-firewall-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-firewall-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-firewall-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.092Z'
+  name: service-firewall-template
+  title: Firewall Rule
+  description: Create and manage firewall rules using Crossplane
+  tags:
+    - source:github-import
+    - crossplane
+    - firewall
+    - security
+    - infrastructure
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: e18d33ec-fc97-416f-961d-0f3e639ba61c
+  etag: 0c865a4c192d99e625755aa3d127c343739931f7
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: resource
+  parameters:
+    - title: Firewall Rule Configuration
+      required:
+        - name
+        - source
+        - destination
+      properties:
+        name:
+          title: Rule Name
+          type: string
+          description: Unique name for this firewall rule
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          ui:autofocus: true
+        namespace:
+          title: Namespace
+          type: string
+          description: Kubernetes namespace for the firewall rule resource
+          default: default
+        source:
+          title: Source IP/CIDR
+          type: string
+          description: Source IP address or CIDR block
+          pattern: ^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:$|\/([0-9]|[1-2][0-9]|3[0-2]))$
+          examples:
+            - 0.0.0.0/0
+            - 192.168.1.0/24
+            - 10.0.0.1
+        destination:
+          title: Destination IP/CIDR
+          type: string
+          description: Destination IP address or CIDR block
+          pattern: ^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:$|\/([0-9]|[1-2][0-9]|3[0-2]))$
+          examples:
+            - 0.0.0.0/0
+            - 172.16.0.0/16
+            - 10.0.0.100
+        protocol:
+          title: Protocol
+          type: string
+          description: Network protocol for the rule
+          default: ALL
+          enum:
+            - ALL
+            - TCP
+            - UDP
+            - ICMP
+          enumNames:
+            - All Protocols
+            - TCP Only
+            - UDP Only
+            - ICMP Only
+        action:
+          title: Action
+          type: string
+          description: Action to take when rule matches
+          default: ACCEPT
+          enum:
+            - ACCEPT
+            - DROP
+            - REJECT
+          enumNames:
+            - Accept (Allow traffic)
+            - Drop (Silently block)
+            - Reject (Block with response)
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the firewall rule
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+    - title: Repository Location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - open-service-portal
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          source: ${{ parameters.source }}
+          destination: ${{ parameters.destination }}
+          protocol: ${{ parameters.protocol }}
+          action: ${{ parameters.action }}
+          owner: ${{ parameters.owner }}
+          repoUrl: ${{ parameters.repoUrl }}
+    - id: publish
+      name: Publish to GitHub
+      action: publish:github
+      input:
+        description: Firewall rule configuration for ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+        gitCommitMessage: 'feat: add firewall rule ${{ parameters.name }}'
+        topics:
+          - crossplane
+          - firewall
+          - security
+    - id: register
+      name: Register in Catalog
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/service-mongodb-golden-path-template-template.yaml
+++ b/templates-old/service-mongodb-golden-path-template-template.yaml
@@ -1,0 +1,196 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-mongodb-golden-path-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-mongodb-golden-path-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-mongodb-golden-path-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-mongodb-golden-path-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-mongodb-golden-path-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.052Z'
+  name: service-mongodb-golden-path-template
+  title: 🚀 MongoDB Golden Path (Complete Stack)
+  description: |
+    The recommended way to provision MongoDB with all dependencies.
+    This template automatically creates: Kubernetes cluster, DNS records, 
+    firewall rules, and the MongoDB database - everything you need in one click!
+  tags:
+    - source:github-import
+    - recommended
+    - golden-path
+    - mongodb
+    - crossplane
+    - infrastructure
+    - stack
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: 481dede2-7915-4fbb-b29d-aeb87c7c32fa
+  etag: 585fe17c51c89a87f22841fe07cd98ee04fd56cc
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: service
+  parameters:
+    - title: 🎯 Quick Setup - Just 3 Questions!
+      description: We'll handle all the infrastructure complexity for you
+      required:
+        - name
+      properties:
+        name:
+          title: Stack Name
+          type: string
+          description: A name for your complete MongoDB stack (lowercase, no spaces)
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          ui:autofocus: true
+          ui:help: 'Example: ''my-app'' will create: my-app-mongodb, my-app-cluster, my-app-dns'
+        storageSize:
+          title: Storage Size (GB)
+          type: integer
+          description: How much storage do you need for your MongoDB?
+          default: 10
+          enum:
+            - 10
+            - 25
+            - 50
+            - 100
+          enumNames:
+            - 10 GB - Development ($10/month)
+            - 25 GB - Small Production ($25/month)
+            - 50 GB - Medium Production ($50/month)
+            - 100 GB - Large Production ($100/month)
+        lifecycle:
+          title: Environment
+          type: string
+          description: What kind of environment is this?
+          default: experimental
+          enum:
+            - experimental
+            - development
+            - staging
+            - production
+          enumNames:
+            - 🧪 Experimental - Just trying things out
+            - 💻 Development - Active development
+            - 🎭 Staging - Pre-production testing
+            - 🚀 Production - Live system
+    - title: 📋 Administrative Details
+      required:
+        - owner
+      properties:
+        owner:
+          title: Team Owner
+          type: string
+          description: Which team will own this MongoDB stack?
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+        namespace:
+          title: Kubernetes Namespace
+          type: string
+          description: Where should we deploy this? (leave empty for 'default')
+          default: default
+  steps:
+    - id: generate-suffix
+      name: 🎲 Generating Unique Resource Identifier
+      action: portal:utils:generateId
+      input:
+        length: 8
+        type: hex
+    - id: log-plan
+      name: 📝 Planning Your Infrastructure
+      action: debug:log
+      input:
+        message: |
+          Creating MongoDB Golden Path Stack: ${{ parameters.name }}
+          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+          ✅ Kubernetes Cluster (3 nodes, medium size)
+          ✅ MongoDB Database (${{ parameters.storageSize }}GB storage)
+          ✅ DNS Record for stable access
+          ✅ Firewall rules for security
+          ✅ Complete Backstage catalog registration
+          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    - id: fetch-base
+      name: 🏗️ Preparing Infrastructure Templates
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          storageSize: ${{ parameters.storageSize }}
+          lifecycle: ${{ parameters.lifecycle }}
+          owner: ${{ parameters.owner }}
+          repoUrl: github.com?owner=open-service-portal&repo=${{ parameters.name }}-${{ steps['generate-suffix'].output.id }}
+          suffix: ${{ steps['generate-suffix'].output.id }}
+          cloudProvider: azure
+    - id: publish
+      name: 📤 Publishing to GitHub
+      action: publish:github
+      input:
+        description: 'MongoDB Golden Path Stack: ${{ parameters.name }} - Complete infrastructure-as-code for MongoDB (${{ parameters.storageSize }}GB), Kubernetes cluster, DNS, and security rules. Managed by Crossplane.'
+        repoUrl: github.com?owner=open-service-portal&repo=${{ parameters.name }}-${{ steps['generate-suffix'].output.id }}
+        defaultBranch: main
+        gitCommitMessage: 'feat: initialize MongoDB golden path stack ${{ parameters.name }}-${{ steps[''generate-suffix''].output.id }}'
+        topics:
+          - mongodb
+          - crossplane
+          - infrastructure-as-code
+          - golden-path
+          - kubernetes
+    - id: register
+      name: 📚 Registering in Service Catalog
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+    - id: log-next-steps
+      name: ✅ Setup Complete!
+      action: debug:log
+      input:
+        message: |
+          Your MongoDB Golden Path Stack is ready!
+          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+          Next steps:
+          1. Apply the Crossplane resources:
+             kubectl apply -f ${{ steps['publish'].output.remoteUrl }}/example.yaml
+
+          2. Watch the provisioning:
+             kubectl get mongodb ${{ parameters.name }} -n ${{ parameters.namespace }} -w
+
+          3. Get your connection string (once ready):
+             kubectl get mongodb ${{ parameters.name }} -n ${{ parameters.namespace }} -o jsonpath='{.status.connString}'
+
+          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  output:
+    text:
+      - title: 🎉 Congratulations!
+        content: |
+          Your MongoDB Golden Path Stack has been created successfully!
+
+          **What we created for you:**
+          - ✅ Complete infrastructure repository
+          - ✅ MongoDB with ${{ parameters.storageSize }}GB storage
+          - ✅ 3-node Kubernetes cluster
+          - ✅ DNS configuration
+          - ✅ Security rules
+          - ✅ Full catalog registration
+    links:
+      - title: 📁 Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+        icon: github
+      - title: 📊 System Overview
+        icon: dashboard
+        entityRef: ${{ steps['register'].output.entityRef }}
+      - title: 📚 Documentation
+        url: ${{ steps['publish'].output.remoteUrl }}/blob/main/README.md
+        icon: docs
+      - title: 🔧 Apply Infrastructure
+        url: ${{ steps['publish'].output.remoteUrl }}/blob/main/example.yaml
+        icon: deploy
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/service-mongodb-template-template.yaml
+++ b/templates-old/service-mongodb-template-template.yaml
@@ -1,0 +1,113 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-mongodb-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-mongodb-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-mongodb-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-mongodb-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-mongodb-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.052Z'
+  name: service-mongodb-template
+  title: MongoDB Database
+  description: Provision a MongoDB database instance using Crossplane
+  tags:
+    - source:github-import
+    - crossplane
+    - database
+    - mongodb
+    - infrastructure
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: fc0e3009-601e-4b1b-af16-0587b926c937
+  etag: 2e03af8f4e73dab7e828b930c73b3dd1e0c1d0a9
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: resource
+  parameters:
+    - title: MongoDB Configuration
+      required:
+        - name
+      properties:
+        name:
+          title: Instance Name
+          type: string
+          description: Unique name for your MongoDB instance
+          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+          ui:autofocus: true
+        namespace:
+          title: Namespace
+          type: string
+          description: Kubernetes namespace for the MongoDB resources
+          default: default
+        storageSize:
+          title: Storage Size (GB)
+          type: integer
+          description: Storage size for the MongoDB instance in GB
+          default: 10
+          minimum: 1
+          maximum: 100
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the MongoDB instance
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+    - title: Repository Location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - open-service-portal
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          namespace: ${{ parameters.namespace }}
+          storageSize: ${{ parameters.storageSize }}
+          owner: ${{ parameters.owner }}
+          repoUrl: ${{ parameters.repoUrl }}
+    - id: publish
+      name: Publish to GitHub
+      action: publish:github
+      input:
+        description: MongoDB instance configuration for ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+        gitCommitMessage: 'feat: add MongoDB instance ${{ parameters.name }}'
+        topics:
+          - crossplane
+          - mongodb
+          - infrastructure
+    - id: register
+      name: Register in Catalog
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/service-nodejs-template-template.yaml
+++ b/templates-old/service-nodejs-template-template.yaml
@@ -1,0 +1,94 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/open-service-portal/service-nodejs-template/tree/main/template.yaml
+    backstage.io/managed-by-origin-location: url:https://github.com/open-service-portal/service-nodejs-template/blob/main/template.yaml
+    backstage.io/view-url: https://github.com/open-service-portal/service-nodejs-template/tree/main/template.yaml
+    backstage.io/edit-url: https://github.com/open-service-portal/service-nodejs-template/edit/main/template.yaml
+    backstage.io/source-location: https://github.com/open-service-portal/service-nodejs-template/tree/main/template.yaml
+    backstage.io/discovered-at: '2025-09-10T08:56:30.052Z'
+  name: service-nodejs-template
+  title: Node.js Service
+  description: Create a new Node.js microservice with Express.js and basic project structure
+  tags:
+    - source:github-import
+    - nodejs
+    - javascript
+    - express
+    - recommended
+    - source:github-discovered
+    - auto-discovered
+    - org:open-service-portal
+    - official
+  uid: d899016a-cda2-49ff-b9a8-b97e7f961fb5
+  etag: da8208836233858a06e4dbbf731049a5b8e1e546
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  owner: group:open-service-portal
+  type: service
+  parameters:
+    - title: Fill in some steps
+      required:
+        - name
+      properties:
+        name:
+          title: Name
+          type: string
+          description: Unique name of the component
+          ui:autofocus: true
+          ui:options:
+            rows: 5
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the component
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+    - title: Choose a location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+            allowedOwners:
+              - open-service-portal
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./content
+        values:
+          name: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+    - id: publish
+      name: Publish
+      action: publish:github
+      input:
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        defaultBranch: main
+    - id: register
+      name: Register
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}
+relations:
+  - type: ownedBy
+    targetRef: group:default/open-service-portal

--- a/templates-old/whoamiapp-openportal.dev--v1alpha1-api.yaml
+++ b/templates-old/whoamiapp-openportal.dev--v1alpha1-api.yaml
@@ -1,0 +1,300 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+  name: whoamiapp-openportal.dev--v1alpha1
+  title: whoamiapp-openportal.dev--v1alpha1
+  uid: cd24b9f8-3cf2-4903-8fcc-ac0f542c0181
+  etag: 5f64bf9c9e2cf8776d83cd3c0b805b89d23f8358
+apiVersion: backstage.io/v1alpha1
+kind: API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: kubernetes-auto-ingested
+  system: kubernets-auto-ingested
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: whoamiapps.openportal.dev
+      version: v1alpha1
+    servers:
+      - url: https://hcp-ebadc4bb-307d-482e-a9d9-fdca15fd5ff1.spot.rackspace.com/
+        description: openportal
+    tags:
+      - name: Cluster Scoped Operations
+        description: Operations on the cluster level
+      - name: Namespace Scoped Operations
+        description: Operations on the namespace level
+      - name: Specific Object Scoped Operations
+        description: Operations on a specific resource
+    paths:
+      /apis/openportal.dev/v1alpha1/whoamiapps:
+        get:
+          tags:
+            - Cluster Scoped Operations
+          summary: List all whoamiapps in all namespaces
+          operationId: listwhoamiappsAllNamespaces
+          responses:
+            '200':
+              description: List of whoamiapps in all namespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/whoamiapps:
+        get:
+          tags:
+            - Namespace Scoped Operations
+          summary: List all whoamiapps in a namespace
+          operationId: listwhoamiapps
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: List of whoamiapps
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+        post:
+          tags:
+            - Namespace Scoped Operations
+          summary: Create a resource
+          operationId: createResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '201':
+              description: Resource created
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/whoamiapps/{name}:
+        get:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Get a WhoAmIApp
+          operationId: getWhoAmIApp
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource details
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    $ref: '#/components/schemas/Resource'
+        put:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Update a resource
+          operationId: updateResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '200':
+              description: Resource updated
+        delete:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Delete a resource
+          operationId: deleteResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource deleted
+    components:
+      schemas:
+        Resource:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              properties:
+                crossplane:
+                  description: Configures how Crossplane will reconcile this composite resource
+                  type: object
+                  properties:
+                    compositionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionUpdatePolicy:
+                      type: string
+                      default: Automatic
+                      enum:
+                        - Automatic
+                        - Manual
+                    resourceRefs:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - apiVersion
+                          - kind
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                      x-kubernetes-list-type: atomic
+                image:
+                  description: Container image to deploy
+                  type: string
+                  default: traefik/whoami:v1.10.1
+                name:
+                  description: Application name (becomes subdomain, e.g., myapp.openportal.dev)
+                  type: string
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                replicas:
+                  description: Number of replicas
+                  type: integer
+                  default: 1
+                  maximum: 3
+                  minimum: 1
+            status:
+              type: object
+              properties:
+                conditions:
+                  description: Conditions of the resource.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                domain:
+                  description: The configured domain for this deployment
+                  type: string
+                ready:
+                  description: Whether the application is ready
+                  type: boolean
+      securitySchemes:
+        bearerHttpAuthentication:
+          description: Bearer token using a JWT
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+    security:
+      - bearerHttpAuthentication: []
+relations:
+  - type: ownedBy
+    targetRef: group:default/kubernetes-auto-ingested
+  - type: partOf
+    targetRef: system:default/kubernets-auto-ingested

--- a/templates-old/whoamiapps.openportal.dev-v1alpha1-template.yaml
+++ b/templates-old/whoamiapps.openportal.dev-v1alpha1-template.yaml
@@ -1,0 +1,263 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+    terasky.backstage.io/crossplane-version: v2
+    terasky.backstage.io/crossplane-scope: Namespaced
+    backstage.io/source-location: url:https://github.com/open-service-portal/template-whoami
+    openportal.dev/tags: demo,application
+    terasky.backstage.io/add-to-catalog: 'true'
+    terasky.backstage.io/component-type: crossplane-template
+    terasky.backstage.io/lifecycle: production
+    terasky.backstage.io/owner: platform-team
+    terasky.backstage.io/system: infrastructure-templates
+    backstage.io/discovered-at: '2025-09-10T08:56:44.167Z'
+  name: whoamiapps.openportal.dev-v1alpha1
+  title: WhoAmIApp
+  description: A template to create a whoamiapps.openportal.dev instance
+  labels:
+    forEntity: system
+    source: crossplane
+    openportal.dev/version: v1.0.4
+    terasky.backstage.io/generate-form: 'true'
+  tags:
+    - source:kubernetes-ingestor
+    - crossplane
+    - cluster:openportal
+  uid: 62980132-23a4-440f-a819-1ff643f20068
+  etag: c58702135ac1542c72c55c197de0a9bc40f07afa
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  type: whoamiapps.openportal.dev
+  parameters:
+    - title: Resource Metadata
+      required:
+        - xrName
+        - owner
+        - xrNamespace
+      properties:
+        xrName:
+          title: Name
+          description: The name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+        xrNamespace:
+          title: Namespace
+          description: 'The namespace in which to create the resource (default: demo)'
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+          default: demo
+        owner:
+          title: Owner
+          description: The owner of the resource
+          type: string
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+      type: object
+    - title: Resource Spec
+      properties:
+        image:
+          description: Container image to deploy
+          type: string
+          ui:placeholder: traefik/whoami:v1.10.1
+        name:
+          description: Application name (becomes subdomain, e.g., myapp.openportal.dev)
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          type: string
+        replicas:
+          description: Number of replicas
+          maximum: 3
+          minimum: 1
+          type: integer
+          ui:placeholder: 1
+      type: object
+    - title: Crossplane Settings
+      properties:
+        crossplane:
+          title: Crossplane Configuration
+          type: object
+          properties:
+            compositionUpdatePolicy:
+              title: Composition Update Policy
+              enum:
+                - Automatic
+                - Manual
+              type: string
+            compositionSelectionStrategy:
+              title: Composition Selection Strategy
+              description: How the composition should be selected.
+              enum:
+                - runtime
+                - direct-reference
+                - label-selector
+              default: runtime
+              type: string
+          dependencies:
+            compositionSelectionStrategy:
+              oneOf:
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - runtime
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - direct-reference
+                    compositionRef:
+                      title: Composition Reference
+                      properties:
+                        name:
+                          type: string
+                          title: Select A Composition By Name
+                          enum:
+                            - whoamiapp
+                          default: whoamiapp
+                      required:
+                        - name
+                      type: object
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - label-selector
+                    compositionSelector:
+                      title: Composition Selector
+                      properties:
+                        matchLabels:
+                          title: Match Labels
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                        - matchLabels
+                      type: object
+      type: object
+    - title: Creation Settings
+      properties:
+        pushToGit:
+          title: Push Manifest to GitOps Repository
+          type: boolean
+          default: true
+      dependencies:
+        pushToGit:
+          oneOf:
+            - properties:
+                pushToGit:
+                  enum:
+                    - false
+            - properties:
+                pushToGit:
+                  enum:
+                    - true
+                manifestLayout:
+                  type: string
+                  description: Layout of the manifest
+                  default: cluster-scoped
+                  ui:help: |-
+                    Choose how the manifest should be generated in the repo.
+                    * Cluster-scoped - a manifest is created for each selected cluster under the root directory of the clusters name
+                    * namespace-scoped - a manifest is created for the resource under the root directory with the namespace name
+                    * custom - a manifest is created under the specified base path
+                  enum:
+                    - cluster-scoped
+                    - namespace-scoped
+                    - custom
+              dependencies:
+                manifestLayout:
+                  oneOf:
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - cluster-scoped
+                        clusters:
+                          title: Target Clusters
+                          description: The target clusters to apply the resource to
+                          type: array
+                          minItems: 1
+                          items:
+                            enum:
+                              - openportal
+                            type: string
+                          uniqueItems: true
+                          ui:widget: checkboxes
+                      required:
+                        - clusters
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - custom
+                        basePath:
+                          type: string
+                          description: Base path in GitOps repository to push the manifest to
+                      required:
+                        - basePath
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - namespace-scoped
+  steps:
+    - id: generateManifest
+      name: Generate Kubernetes Resource Manifest
+      action: terasky:claim-template
+      input:
+        parameters: ${{ parameters }}
+        nameParam: xrName
+        namespaceParam: xrNamespace
+        ownerParam: owner
+        excludeParams:
+          - crossplane.compositionSelectionStrategy
+          - owner
+          - pushToGit
+          - basePath
+          - manifestLayout
+          - _editData
+          - targetBranch
+          - repoUrl
+          - clusters
+          - xrName
+          - xrNamespace
+        apiVersion: openportal.dev/v1alpha1
+        kind: WhoAmIApp
+        clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}
+        removeEmptyParams: true
+    - id: moveNamespacedManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'namespace-scoped' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.xrNamespace }}/${{ steps.generateManifest.input.kind }}/${{ steps.generateManifest.output.filePaths[0].split('/').pop() }}
+    - id: moveCustomManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'custom' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.basePath }}/${{ parameters.xrName }}.yaml
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      if: ${{ parameters.pushToGit }}
+      input:
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
+        branchName: create-${{ parameters.xrName }}-resource
+        title: Create WhoAmIApp Resource ${{ parameters.xrName }}
+        description: Create WhoAmIApp Resource ${{ parameters.xrName }}
+        targetBranchName: main
+  output:
+    links:
+      - title: Download YAML Manifest
+        url: data:application/yaml;charset=utf-8,${{ steps.generateManifest.output.manifest }}
+      - title: Open Pull Request
+        if: ${{ parameters.pushToGit }}
+        url: ${{ steps["create-pull-request"].output.remoteUrl }}
+relations: []

--- a/templates-old/whoamiservice-openportal.dev--v1alpha1-api.yaml
+++ b/templates-old/whoamiservice-openportal.dev--v1alpha1-api.yaml
@@ -1,0 +1,305 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+  name: whoamiservice-openportal.dev--v1alpha1
+  title: whoamiservice-openportal.dev--v1alpha1
+  uid: fe57d7c2-2751-4489-be54-7e6d0963e987
+  etag: 125b812ba7cca4fe75fc8fbd49aeff5739a01b9f
+apiVersion: backstage.io/v1alpha1
+kind: API
+spec:
+  type: openapi
+  lifecycle: production
+  owner: kubernetes-auto-ingested
+  system: kubernets-auto-ingested
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: whoamiservices.openportal.dev
+      version: v1alpha1
+    servers:
+      - url: https://hcp-ebadc4bb-307d-482e-a9d9-fdca15fd5ff1.spot.rackspace.com/
+        description: openportal
+    tags:
+      - name: Cluster Scoped Operations
+        description: Operations on the cluster level
+      - name: Namespace Scoped Operations
+        description: Operations on the namespace level
+      - name: Specific Object Scoped Operations
+        description: Operations on a specific resource
+    paths:
+      /apis/openportal.dev/v1alpha1/whoamiservices:
+        get:
+          tags:
+            - Cluster Scoped Operations
+          summary: List all whoamiservices in all namespaces
+          operationId: listwhoamiservicesAllNamespaces
+          responses:
+            '200':
+              description: List of whoamiservices in all namespaces
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/whoamiservices:
+        get:
+          tags:
+            - Namespace Scoped Operations
+          summary: List all whoamiservices in a namespace
+          operationId: listwhoamiservices
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: List of whoamiservices
+              content:
+                application/json:
+                  schema:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Resource'
+        post:
+          tags:
+            - Namespace Scoped Operations
+          summary: Create a resource
+          operationId: createResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '201':
+              description: Resource created
+      /apis/openportal.dev/v1alpha1/namespaces/{namespace}/whoamiservices/{name}:
+        get:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Get a WhoAmIService
+          operationId: getWhoAmIService
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource details
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    $ref: '#/components/schemas/Resource'
+        put:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Update a resource
+          operationId: updateResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  $ref: '#/components/schemas/Resource'
+          responses:
+            '200':
+              description: Resource updated
+        delete:
+          tags:
+            - Specific Object Scoped Operations
+          summary: Delete a resource
+          operationId: deleteResource
+          parameters:
+            - name: namespace
+              in: path
+              required: true
+              schema:
+                type: string
+            - name: name
+              in: path
+              required: true
+              schema:
+                type: string
+          responses:
+            '200':
+              description: Resource deleted
+    components:
+      schemas:
+        Resource:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+            spec:
+              type: object
+              required:
+                - name
+              properties:
+                crossplane:
+                  description: Configures how Crossplane will reconcile this composite resource
+                  type: object
+                  properties:
+                    compositionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                    compositionRevisionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionSelector:
+                      type: object
+                      required:
+                        - matchLabels
+                      properties:
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    compositionUpdatePolicy:
+                      type: string
+                      default: Automatic
+                      enum:
+                        - Automatic
+                        - Manual
+                    resourceRefs:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - apiVersion
+                          - kind
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                      x-kubernetes-list-type: atomic
+                name:
+                  description: Service name (becomes subdomain, e.g., myapp.example.com)
+                  type: string
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            status:
+              type: object
+              properties:
+                appReady:
+                  description: Whether the application is deployed and ready
+                  type: boolean
+                conditions:
+                  description: Conditions of the resource.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                dnsReady:
+                  description: Whether the DNS record is configured
+                  type: boolean
+                domain:
+                  description: The full domain name for accessing the service
+                  type: string
+                ingressHost:
+                  description: The ingress hostname
+                  type: string
+                ipAddress:
+                  description: The IP address the DNS points to
+                  type: string
+      securitySchemes:
+        bearerHttpAuthentication:
+          description: Bearer token using a JWT
+          type: http
+          scheme: bearer
+          bearerFormat: JWT
+    security:
+      - bearerHttpAuthentication: []
+relations:
+  - type: apiConsumedBy
+    targetRef: component:demo/whoami-demo-openportal
+  - type: apiConsumedBy
+    targetRef: component:test/whoami-openportal
+  - type: ownedBy
+    targetRef: group:default/kubernetes-auto-ingested
+  - type: partOf
+    targetRef: system:default/kubernets-auto-ingested

--- a/templates-old/whoamiservices.openportal.dev-v1alpha1-template.yaml
+++ b/templates-old/whoamiservices.openportal.dev-v1alpha1-template.yaml
@@ -1,0 +1,256 @@
+metadata:
+  namespace: default
+  annotations:
+    backstage.io/managed-by-location: 'cluster: openportal'
+    backstage.io/managed-by-origin-location: 'cluster: openportal'
+    terasky.backstage.io/crossplane-version: v2
+    terasky.backstage.io/crossplane-scope: Namespaced
+    backstage.io/source-location: url:https://github.com/open-service-portal/template-whoami-service
+    crossplane.io/version: v2.0
+    description: WhoAmI application with automatic DNS configuration
+    openportal.dev/tags: service,composite
+    terasky.backstage.io/add-to-catalog: 'true'
+    terasky.backstage.io/component-type: crossplane-template
+    terasky.backstage.io/dependsOn: template:default/whoamiapps.openportal.dev-v1alpha1,template:default/dnsrecords.openportal.dev-v1alpha1
+    terasky.backstage.io/lifecycle: production
+    terasky.backstage.io/owner: platform-team
+    terasky.backstage.io/system: infrastructure-templates
+    backstage.io/discovered-at: '2025-09-10T08:56:44.167Z'
+  name: whoamiservices.openportal.dev-v1alpha1
+  title: WhoAmIService
+  description: A template to create a whoamiservices.openportal.dev instance
+  labels:
+    forEntity: system
+    source: crossplane
+    openportal.dev/version: v2.0.2
+    terasky.backstage.io/generate-form: 'true'
+  tags:
+    - source:kubernetes-ingestor
+    - crossplane
+    - cluster:openportal
+  uid: c70e38fc-1610-4d7b-93ac-7861a2c4f172
+  etag: e7f508b2b14bb7eeac68d1c8d0b133ef1e3be237
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+spec:
+  type: whoamiservices.openportal.dev
+  parameters:
+    - title: Resource Metadata
+      required:
+        - xrName
+        - owner
+        - xrNamespace
+      properties:
+        xrName:
+          title: Name
+          description: The name of the resource
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+        xrNamespace:
+          title: Namespace
+          description: 'The namespace in which to create the resource (default: demo)'
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          maxLength: 63
+          type: string
+          default: demo
+        owner:
+          title: Owner
+          description: The owner of the resource
+          type: string
+          ui:field: OwnerPicker
+          ui:options:
+            catalogFilter:
+              kind: Group
+      type: object
+    - title: Resource Spec
+      properties:
+        name:
+          description: Service name (becomes subdomain, e.g., myapp.example.com)
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+          type: string
+      type: object
+    - title: Crossplane Settings
+      properties:
+        crossplane:
+          title: Crossplane Configuration
+          type: object
+          properties:
+            compositionUpdatePolicy:
+              title: Composition Update Policy
+              enum:
+                - Automatic
+                - Manual
+              type: string
+            compositionSelectionStrategy:
+              title: Composition Selection Strategy
+              description: How the composition should be selected.
+              enum:
+                - runtime
+                - direct-reference
+                - label-selector
+              default: runtime
+              type: string
+          dependencies:
+            compositionSelectionStrategy:
+              oneOf:
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - runtime
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - direct-reference
+                    compositionRef:
+                      title: Composition Reference
+                      properties:
+                        name:
+                          type: string
+                          title: Select A Composition By Name
+                          enum:
+                            - whoamiservice
+                          default: whoamiservice
+                      required:
+                        - name
+                      type: object
+                - properties:
+                    compositionSelectionStrategy:
+                      enum:
+                        - label-selector
+                    compositionSelector:
+                      title: Composition Selector
+                      properties:
+                        matchLabels:
+                          title: Match Labels
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                        - matchLabels
+                      type: object
+      type: object
+    - title: Creation Settings
+      properties:
+        pushToGit:
+          title: Push Manifest to GitOps Repository
+          type: boolean
+          default: true
+      dependencies:
+        pushToGit:
+          oneOf:
+            - properties:
+                pushToGit:
+                  enum:
+                    - false
+            - properties:
+                pushToGit:
+                  enum:
+                    - true
+                manifestLayout:
+                  type: string
+                  description: Layout of the manifest
+                  default: cluster-scoped
+                  ui:help: |-
+                    Choose how the manifest should be generated in the repo.
+                    * Cluster-scoped - a manifest is created for each selected cluster under the root directory of the clusters name
+                    * namespace-scoped - a manifest is created for the resource under the root directory with the namespace name
+                    * custom - a manifest is created under the specified base path
+                  enum:
+                    - cluster-scoped
+                    - namespace-scoped
+                    - custom
+              dependencies:
+                manifestLayout:
+                  oneOf:
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - cluster-scoped
+                        clusters:
+                          title: Target Clusters
+                          description: The target clusters to apply the resource to
+                          type: array
+                          minItems: 1
+                          items:
+                            enum:
+                              - openportal
+                            type: string
+                          uniqueItems: true
+                          ui:widget: checkboxes
+                      required:
+                        - clusters
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - custom
+                        basePath:
+                          type: string
+                          description: Base path in GitOps repository to push the manifest to
+                      required:
+                        - basePath
+                    - properties:
+                        manifestLayout:
+                          enum:
+                            - namespace-scoped
+  steps:
+    - id: generateManifest
+      name: Generate Kubernetes Resource Manifest
+      action: terasky:claim-template
+      input:
+        parameters: ${{ parameters }}
+        nameParam: xrName
+        namespaceParam: xrNamespace
+        ownerParam: owner
+        excludeParams:
+          - crossplane.compositionSelectionStrategy
+          - owner
+          - pushToGit
+          - basePath
+          - manifestLayout
+          - _editData
+          - targetBranch
+          - repoUrl
+          - clusters
+          - xrName
+          - xrNamespace
+        apiVersion: openportal.dev/v1alpha1
+        kind: WhoAmIService
+        clusters: ${{ parameters.clusters if parameters.manifestLayout === 'cluster-scoped' and parameters.pushToGit else ['temp'] }}
+        removeEmptyParams: true
+    - id: moveNamespacedManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'namespace-scoped' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.xrNamespace }}/${{ steps.generateManifest.input.kind }}/${{ steps.generateManifest.output.filePaths[0].split('/').pop() }}
+    - id: moveCustomManifest
+      name: Move and Rename Manifest
+      if: ${{ parameters.manifestLayout === 'custom' }}
+      action: fs:rename
+      input:
+        files:
+          - from: ${{ steps.generateManifest.output.filePaths[0] }}
+            to: ./${{ parameters.basePath }}/${{ parameters.xrName }}.yaml
+    - id: create-pull-request
+      name: create-pull-request
+      action: publish:github:pull-request
+      if: ${{ parameters.pushToGit }}
+      input:
+        repoUrl: github.com?owner=open-service-portal&repo=catalog-orders
+        branchName: create-${{ parameters.xrName }}-resource
+        title: Create WhoAmIService Resource ${{ parameters.xrName }}
+        description: Create WhoAmIService Resource ${{ parameters.xrName }}
+        targetBranchName: main
+  output:
+    links:
+      - title: Download YAML Manifest
+        url: data:application/yaml;charset=utf-8,${{ steps.generateManifest.output.manifest }}
+      - title: Open Pull Request
+        if: ${{ parameters.pushToGit }}
+        url: ${{ steps["create-pull-request"].output.remoteUrl }}
+relations: []


### PR DESCRIPTION
## Summary

This PR adds a workspace-level wrapper script for the xrd-transform CLI tool, making it easily accessible from anywhere in the workspace without needing to navigate to the plugin directory.

## Changes

### 1. Wrapper Script (`scripts/xrd-transform.sh`)

**Features:**
- Automatically handles directory navigation to plugin location
- Resolves paths correctly relative to user's working directory
- Supports all xrd-transform CLI options
- Works with both file input and stdin (pipes)
- Comprehensive usage documentation in script comments

**Usage Examples:**
```bash
# Transform from file
./scripts/xrd-transform.sh template-namespace/configuration/xrd.yaml

# Transform with options
./scripts/xrd-transform.sh -v --only template xrd.yaml -o output/

# Transform from stdin
cat xrd.yaml | ./scripts/xrd-transform.sh

# Use custom templates
./scripts/xrd-transform.sh -t my-templates xrd.yaml
```

### 2. Path Resolution Fix

The script correctly resolves relative paths from the user's current directory:

**Before:**
```bash
cd workspace/
./scripts/xrd-transform.sh xrd.yaml -o test
# ❌ Created: app-portal/plugins/ingestor/test (wrong!)
```

**After:**
```bash
cd workspace/
./scripts/xrd-transform.sh xrd.yaml -o test
# ✅ Creates: workspace/test (correct!)
```

**Implementation:**
- Saves user's CWD before changing to plugin directory
- Detects `-o`/`--output` and `-t`/`--templates` options
- Makes path arguments absolute relative to user's CWD
- Input files also resolved relative to user's CWD first
- Falls back to workspace-relative paths if file not found in CWD

### 3. Additional Fixes

**Fix ts-node wrapper scripts** (`767e8aa`)
- Added `--project tsconfig.cli.json` flag to ts-node commands
- Fixes TypeScript module resolution errors (ERR_UNKNOWN_FILE_EXTENSION)
- Applied to both `template-ingest.sh` and `template-export.sh`

## Testing

Tested various scenarios:

✅ Transform from workspace root
```bash
cd portal-workspace/
./scripts/xrd-transform.sh template-namespace/configuration/xrd.yaml
```

✅ Transform with output directory
```bash
./scripts/xrd-transform.sh xrd.yaml -o ./output
# Creates: portal-workspace/output/
```

✅ Transform from subdirectory
```bash
cd template-namespace/
../scripts/xrd-transform.sh configuration/xrd.yaml
```

✅ Transform with custom templates
```bash
./scripts/xrd-transform.sh -t ./my-templates xrd.yaml
```

✅ Pipe input
```bash
cat xrd.yaml | ./scripts/xrd-transform.sh -v
```

## Files Changed

- `scripts/xrd-transform.sh` (NEW) - Wrapper script with path resolution
- `scripts/template-ingest.sh` - Added --project flag
- `scripts/template-export.sh` - Added --project flag

## Compatibility

This wrapper works with the xrd-transform CLI tool in the ingestor plugin:
- Related PR: open-service-portal/ingestor#4
- Plugin path: `app-portal/plugins/ingestor/`
- CLI path: `src/xrd-transform/cli/xrd-transform-cli.ts`

## Benefits

1. **Improved UX**: No need to remember plugin path or ts-node command
2. **Consistent Interface**: Matches existing wrapper scripts (template-ingest.sh, template-export.sh)
3. **Correct Path Handling**: Paths resolved from where user runs command
4. **Flexible Usage**: Works with files, directories, and stdin

## Next Steps

After merging:
- [ ] Update workspace README with xrd-transform examples
- [ ] Add xrd-transform.sh to documentation
- [ ] Consider adding bash completion for options