### PR TITLE
fix: escape angle brackets in template-standards.md for MDX

### DIFF
--- a/docs/template-standards.md
+++ b/docs/template-standards.md
@@ -390,8 +390,8 @@ crossplane-cli = "latest"
 ## Examples Structure
 
 Provide at least:
-1. **basic-\<resource\>.yaml** - Minimal configuration
-2. **\<resource\>-with-\<feature\>.yaml** - Advanced features
+1. `basic-<resource>.yaml` - Minimal configuration
+2. `<resource>-with-<feature>.yaml` - Advanced features
 
 Example format:
 ```yaml

--- a/docs/template-standards.md
+++ b/docs/template-standards.md
@@ -390,8 +390,8 @@ crossplane-cli = "latest"
 ## Examples Structure
 
 Provide at least:
-1. **basic-<resource>.yaml** - Minimal configuration
-2. **<resource>-with-<feature>.yaml** - Advanced features
+1. **basic-\<resource\>.yaml** - Minimal configuration
+2. **\<resource\>-with-\<feature\>.yaml** - Advanced features
 
 Example format:
 ```yaml


### PR DESCRIPTION
## Summary
- Fixed MDX compilation error in `template-standards.md`
- Changed `<resource>` and `<feature>` from bold to inline code

## Problem
Docusaurus build failed with:
```
Error: MDX compilation failed for file "external-docs/portal-workspace/template-standards.md"
Cause: Expected a closing tag for `<resource>` (393:12-393:22) before the end of `strong`
```

MDX interprets `<...>` as JSX tags when used in bold formatting.

## Solution
Use inline code instead of bold for file name placeholders:
- Before: `**<resource>**`
- After: `` `<resource>` ``

Inline code is semantically more appropriate for placeholders and doesn't require escaping in MDX.

## Test Plan
- [x] Local edit verified
- [ ] Wait for Docusaurus workflow to pass

Fixes workflow run: https://github.com/open-service-portal/docusaurus/actions/runs/18181942749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
