### PR TITLE
fix: wrap template literals in inline code for MDX

### DIFF
--- a/docs/cluster/manifests.md
+++ b/docs/cluster/manifests.md
@@ -57,8 +57,8 @@ Functions transform resource specifications in the composition pipeline:
 
 **Config Manifests** (`manifests-config-openportal/`):
 - **environment-configs.yaml** - Production overrides (uses envsubst)
-  - dns-config: zone=${DNS_ZONE}, provider=${DNS_PROVIDER}
-  - cloudflare-config: zone_id=${CLOUDFLARE_ZONE_ID}, account_id=${CLOUDFLARE_ACCOUNT_ID}
+  - dns-config: zone=`${DNS_ZONE}`, provider=`${DNS_PROVIDER}`
+  - cloudflare-config: zone_id=`${CLOUDFLARE_ZONE_ID}`, account_id=`${CLOUDFLARE_ACCOUNT_ID}`
 - **cloudflare-zone-openportal-dev.yaml** - Zone import for openportal.dev
 
 ### GitOps Integration

--- a/docs/cluster/setup.md
+++ b/docs/cluster/setup.md
@@ -60,7 +60,7 @@ This script will:
 7. Install External-DNS for DNS management
 8. Install platform-wide environment configurations
 9. Create Backstage service account with K8s integration
-10. Generate app-config.${context}.local.yaml with cluster credentials (if app-portal exists)
+10. Generate `app-config.${context}.local.yaml` with cluster credentials (if app-portal exists)
 
 The script works with any Kubernetes cluster and uses manifests from [`scripts/manifests-setup-cluster/`](../../scripts/manifests-setup-cluster/).
 


### PR DESCRIPTION
## Summary
- Fixed MDX/SSG runtime errors caused by unescaped template literals
- Wrapped environment variable placeholders in inline code

## Problem
Docusaurus static site generation failed with:
```
ReferenceError: DNS_ZONE is not defined
ReferenceError: context is not defined
```

MDX interprets `${...}` as JavaScript template literals during SSG.

## Solution
Wrapped all template literal placeholders in backticks:
- `${DNS_ZONE}`, `${DNS_PROVIDER}` in manifests.md
- `${CLOUDFLARE_ZONE_ID}`, `${CLOUDFLARE_ACCOUNT_ID}` in manifests.md
- `${context}` in setup.md

## Files Changed
- `docs/cluster/manifests.md` - Environment variable placeholders
- `docs/cluster/setup.md` - Context variable placeholder

## Test Plan
- [x] Local edits verified
- [ ] Wait for Docusaurus workflow to pass

Fixes workflow run: https://github.com/open-service-portal/docusaurus/actions/runs/18185493140

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved readability in cluster manifests docs by rendering environment variable substitutions as inline code.
  * Consistently formatted provider identifiers (e.g., Cloudflare IDs) using inline code for clearer reference.
  * Updated automated setup instructions to display the app-config filename in inline code, making the step easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->