### PR TITLE
chore: remove deploy-app-portal references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .github/
 github-org-settings/
 /app-portal/
-/deploy-app-portal/
 catalog/
 catalog-orders/
 docusaurus/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,6 @@ open-service-portal/         # THIS directory = portal-workspace repo
 ├── catalog-orders/         # NESTED repo - XR instances from Backstage
 │   └── (structure managed by template publishPhase)
 ├── concepts/               # Architecture and design documentation
-├── deploy-app-portal/      # NESTED repo - Kubernetes deployment manifests
 │
 ├── template-dns-record/    # NESTED repo - Mock DNS template
 │   └── configuration/
@@ -164,7 +163,7 @@ git clone https://github.com/open-service-portal/ingestor.git
 - **service-cluster-template/** - Kubernetes cluster provisioning (git@github.com:open-service-portal/service-cluster-template.git)
 
 #### Deployment & Infrastructure
-- **deploy-app-portal/** - Kubernetes deployment manifests for Backstage (git@github.com:open-service-portal/deploy-app-portal.git)
+- Kubernetes deployment manifests for Backstage live in `app-portal/deploy/kubernetes/`
 
 #### Documentation & Workspace
 - **portal-workspace/** - This workspace repository with documentation and setup scripts (git@github.com:open-service-portal/portal-workspace.git)


### PR DESCRIPTION
## Summary
- Remove references to the no-longer-existing `deploy-app-portal` repo
- Kubernetes deployment manifests now live in `app-portal/deploy/kubernetes/`

## Test plan
- [x] `.gitignore` entry removed
- [x] `CLAUDE.md` tree + Deployment section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to reflect the reorganized location of Kubernetes deployment manifests.

* **Chores**
  * Removed git ignore rule for deploy-app-portal directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->