### PR TITLE
chore: enable internal plugins for workspace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "enabledPlugins": {
+    "workspace@ai-plugins-internal": true,
+    "knowledge@ai-plugins-internal": true,
+    "craft@ai-plugins-internal": true
+  }
+}


### PR DESCRIPTION
Enables the `workspace`, `knowledge`, and `craft` plugins from the `ai-plugins-internal` marketplace at project scope via `.claude/settings.json`.

`agent-sync` stays enabled globally; the rest are scoped to this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal settings to turn on additional built-in capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->