### PR TITLE
chore: enable agent-sync plugin in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
+    "agent-sync@ai-plugins-internal": true,
     "workspace@ai-plugins-internal": true,
     "knowledge@ai-plugins-internal": true,
     "craft@ai-plugins-internal": true


### PR DESCRIPTION
Adds `agent-sync@ai-plugins-internal` to the project-scoped `.claude/settings.json`.