### PR TITLE
chore: gitignore backstage-plugins nested repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ catalog-orders/
 docusaurus/
 ingestor/
 oidc-authenticator/
+backstage-plugins/
 
 # Service Template Repositories
 templates/


### PR DESCRIPTION
Adds `backstage-plugins/` to `.gitignore` so the newly cloned nested repo doesn't show as untracked in the workspace worktree.