### PR TITLE
docs: remove internal/personal references from valkey spec

### DIFF
--- a/docs/specs/valkey-service.md
+++ b/docs/specs/valkey-service.md
@@ -150,7 +150,6 @@ New repo **`template-valkey`** following [template-standards.md](../template-sta
 ## 10. References
 
 - Spike findings (companion doc): [valkey-spike-findings.md](./valkey-spike-findings.md)
-- Operator source (local): `_work/reference/valkey-io/valkey-operator/` (`api/v1alpha1/*_types.go`, `config/samples/`)
-- Helm chart (local): `_work/reference/valkey-io/valkey-helm/`
-- Existing pattern: `template-whoami/configuration/` (XRD + Pipeline Composition)
-- Felix strawman (not yet pushed): `main/docs/specs/valkey-service.md` (his machine)
+- Operator: <https://github.com/valkey-io/valkey-operator> (`api/v1alpha1/*_types.go`, `config/samples/`)
+- Helm chart: <https://valkey.io/valkey-helm>
+- Existing pattern: `template-whoami` (XRD + Pipeline Composition)


### PR DESCRIPTION
Cleans §10 References in `docs/specs/valkey-service.md`:
- removes the `Felix strawman (not yet pushed) … (his machine)` line — an internal/personal reference that should never be in a public repo,
- replaces machine-local `_work/reference/…` paths with upstream URLs.

Public-repo hygiene: no personal names tied to internal coordination, no local machine paths, no 'not yet pushed' notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)