### PR TITLE
docs: rename workspace repo to open-service-portal/open-service-portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Workspace Structure
 
-**IMPORTANT**: This directory IS the portal-workspace repository itself!
+**IMPORTANT**: This directory IS the open-service-portal repository itself!
 
 It serves as a parent/workspace repository that:
 - Contains shared documentation and configuration
@@ -16,8 +16,8 @@ It serves as a parent/workspace repository that:
 - These nested repositories are gitignored and managed independently
 
 ```
-open-service-portal/         # THIS directory = portal-workspace repo
-├── .git/                   # portal-workspace git (own repository)
+open-service-portal/         # THIS directory = open-service-portal repo
+├── .git/                   # open-service-portal git (own repository)
 ├── CLAUDE.md               # Workspace-level context (this file)
 ├── README.md               # Workspace overview
 ├── specs/                  # Spec-driven specs, folder-per-feature (NNNN_product_<feature>_<topic>.md)
@@ -116,10 +116,10 @@ To set up the complete workspace, clone all repositories:
 
 ```bash
 # Clone the workspace
-git clone https://github.com/open-service-portal/portal-workspace.git
+git clone https://github.com/open-service-portal/open-service-portal.git
 
 # Navigate to the workspace
-cd portal-workspace
+cd open-service-portal
 
 # Clone the app-portal code repository inside the workspace
 git clone https://github.com/open-service-portal/app-portal.git
@@ -170,7 +170,7 @@ git clone https://github.com/open-service-portal/ingestor.git
 - Kubernetes deployment manifests for Backstage live in `app-portal/deploy/kubernetes/`
 
 #### Documentation & Workspace
-- **portal-workspace/** - This workspace repository with documentation and setup scripts (git@github.com:open-service-portal/portal-workspace.git)
+- **open-service-portal/** - This workspace repository with documentation and setup scripts (git@github.com:open-service-portal/open-service-portal.git)
 - **specs/** - Spec-driven specs, folder-per-feature (`<feature>/NNNN_product_<feature>_<topic>.md`); intent, never under `docs/`. See [specs/README.md](./specs/README.md)
 - **docs/decisions/** - Dated architecture/design decisions (formerly `concepts/`)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To set up this workspace, clone each repository:
 
 ```bash
 # Clone the workspace (this repository)
-git clone git@github.com:open-service-portal/portal-workspace.git open-service-portal
+git clone git@github.com:open-service-portal/open-service-portal.git open-service-portal
 cd open-service-portal
 
 # Clone core application repository

--- a/docs/backstage/README.md
+++ b/docs/backstage/README.md
@@ -41,7 +41,7 @@ Much of the documentation in this directory (especially [new-frontend-system/](.
 
 ### 1. Source Code Reference
 
-The [/backstage/](https://github.com/open-service-portal/portal-workspace/tree/main/backstage) directory in this workspace contains local clones of:
+The [/backstage/](https://github.com/open-service-portal/open-service-portal/tree/main/backstage) directory in this workspace contains local clones of:
 - **Backstage core** - Official source code and documentation
 - **Community plugins** - 100+ community plugin implementations
 - **TeraSky plugins** - Additional plugin examples

--- a/docs/backstage/examples/README.md
+++ b/docs/backstage/examples/README.md
@@ -434,7 +434,7 @@ const myExtension = createExtension({
 ## Contributing
 
 Found a bug in an example or have a suggestion?
-1. Open an issue: [GitHub Issues](https://github.com/open-service-portal/portal-workspace/issues)
+1. Open an issue: [GitHub Issues](https://github.com/open-service-portal/open-service-portal/issues)
 2. Create a PR with fix/improvement
 3. Include test results if applicable
 

--- a/docs/backstage/new-frontend-system/INDEX.md
+++ b/docs/backstage/new-frontend-system/INDEX.md
@@ -481,7 +481,7 @@ See [`examples/README.md`](../examples/README.md) for Docker setup details.
 ## 🤝 Contributing
 
 Found an error or want to improve the documentation?
-1. Check existing issues: [GitHub Issues](https://github.com/open-service-portal/portal-workspace/issues)
+1. Check existing issues: [GitHub Issues](https://github.com/open-service-portal/open-service-portal/issues)
 2. Create a PR with your changes
 3. Update the requirements tracking if you answer new questions
 

--- a/docs/cli-tools.md
+++ b/docs/cli-tools.md
@@ -259,7 +259,7 @@ jobs:
 4. **Path resolution issues**
    ```bash
    # Scripts expect to run from workspace root
-   cd /path/to/portal-workspace
+   cd /path/to/open-service-portal
    ./scripts/template-ingest.sh ./xrd.yaml
    ```
 

--- a/docs/cluster/setup.md
+++ b/docs/cluster/setup.md
@@ -33,7 +33,7 @@ yq --version
 We provide a script that automates the entire setup process:
 
 ```bash
-# Run from the portal-workspace directory
+# Run from the open-service-portal directory
 ./scripts/cluster-setup.sh
 ```
 

--- a/docs/testing-ingestor-plugin.md
+++ b/docs/testing-ingestor-plugin.md
@@ -43,7 +43,7 @@ Deploy updated XRDs with new annotation namespaces to the cluster.
 **Important**: The cluster uses Flux GitOps which syncs from the `catalog` repository every 1 minute. We need to suspend this to prevent Flux from overwriting our local XRD changes.
 
 ```bash
-cd /Users/felix/work/open-service-portal/portal-workspace
+cd /Users/felix/work/open-service-portal/open-service-portal
 
 # Suspend Flux synchronization for local testing
 ./scripts/template-sync.sh stop
@@ -101,7 +101,7 @@ Test the standalone CLI tool with updated XRDs.
 #### 2.1 Test Namespace Template (Cluster-Scoped)
 
 ```bash
-cd /Users/felix/work/open-service-portal/portal-workspace
+cd /Users/felix/work/open-service-portal/open-service-portal
 
 # Generate templates from XRD
 ./scripts/template-ingest.sh template-namespace -o /tmp/test-namespace
@@ -156,7 +156,7 @@ Build the ingestor plugin and start Backstage with the updated configuration.
 #### 3.1 Install Dependencies (if needed)
 
 ```bash
-cd /Users/felix/work/open-service-portal/portal-workspace/app-portal
+cd /Users/felix/work/open-service-portal/open-service-portal/app-portal
 
 # Install dependencies
 yarn install
@@ -179,7 +179,7 @@ ls -la dist/
 Ensure you have the cluster-specific configuration:
 
 ```bash
-cd /Users/felix/work/open-service-portal/portal-workspace
+cd /Users/felix/work/open-service-portal/open-service-portal
 
 # Run cluster config script to set up Backstage config
 ./scripts/cluster-config.sh
@@ -190,7 +190,7 @@ This should create/update `app-portal/app-config.rancher-desktop.local.yaml`.
 #### 3.4 Start Backstage
 
 ```bash
-cd /Users/felix/work/open-service-portal/portal-workspace/app-portal
+cd /Users/felix/work/open-service-portal/open-service-portal/app-portal
 
 # Start Backstage (auto-detects rancher-desktop context)
 yarn start
@@ -519,7 +519,7 @@ kubectl delete managednamespace test-managed-ns
 kubectl delete namespace test-managed-ns
 
 # Resume Flux synchronization (IMPORTANT!)
-cd /Users/felix/work/open-service-portal/portal-workspace
+cd /Users/felix/work/open-service-portal/open-service-portal
 ./scripts/template-sync.sh start
 ```
 

--- a/docs/users/rbac-scripts-overview.md
+++ b/docs/users/rbac-scripts-overview.md
@@ -1,6 +1,6 @@
 # RBAC Management Scripts Overview
 
-This document provides an overview of all RBAC management scripts available in the portal-workspace.
+This document provides an overview of all RBAC management scripts available in the open-service-portal.
 
 ## Understanding Kubernetes Groups
 


### PR DESCRIPTION
## What

The workspace/parent repo was renamed on GitHub from `open-service-portal/portal-workspace` to `open-service-portal/open-service-portal`. This updates the now-stale references in `CLAUDE.md`, `README.md`, and `docs/` to the canonical name.

## Why

The old name resolves only via GitHub's rename redirect. That redirect breaks the moment the old name is reused within the org, so the documentation, clone URLs, and GitHub links should point at the canonical repository name.

## Changes

- `CLAUDE.md` — clone URL, `cd` target, the repo identity line, and the repository-overview entry.
- `README.md` — clone URL (still clones into an `open-service-portal/` directory).
- `docs/**` — GitHub issue/source links and `cd` path references.

## Out of scope (intentionally)

- `journal/**` entries keep the old name as historical records.
- The example paths in `docs/testing-ingestor-plugin.md` still contain a personal home directory (`/Users/felix/...`); only the repo-name segment was renamed here. Genericizing those paths is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
