### PR TITLE
fix(cluster-config): key catalog-orders Kustomization on cluster name, not context

### DIFF
--- a/scripts/cluster-config.sh
+++ b/scripts/cluster-config.sh
@@ -194,9 +194,8 @@ configure_flux_catalog_orders() {
         return 1
     fi
 
-    # Export CLUSTER_NAME for envsubst (keeping CURRENT_CONTEXT for backward compatibility)
+    # Export CLUSTER_NAME for envsubst in flux-catalog-orders.yaml
     export CLUSTER_NAME
-    export CURRENT_CONTEXT="${CLUSTER_NAME}"
 
     # Apply catalog-orders configuration with environment substitution
     if envsubst < "$MANIFEST_DIR/flux-catalog-orders.yaml" | kubectl apply -f -; then

--- a/scripts/manifests/config/flux-catalog-orders.yaml
+++ b/scripts/manifests/config/flux-catalog-orders.yaml
@@ -1,7 +1,8 @@
 # Flux GitOps: Catalog Orders Watcher
 # Purpose: Monitors and syncs XR instances created by Backstage templates
-# Creates a context-specific Kustomization: catalog-orders-${CURRENT_CONTEXT}
-# This allows multiple contexts to coexist on the same cluster
+# Creates a cluster-specific Kustomization: catalog-orders-${CLUSTER_NAME}
+# The path matches the catalog-orders repo layout (one directory per cluster).
+# Contexts that share a cluster (e.g. cert-auth and OIDC) share one Kustomization.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -17,15 +18,15 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: catalog-orders-${CURRENT_CONTEXT}
+  name: catalog-orders-${CLUSTER_NAME}
   namespace: flux-system
 spec:
   interval: 1m0s
   sourceRef:
     kind: GitRepository
     name: catalog-orders
-  # Path based on current kubectl context
-  path: "./${CURRENT_CONTEXT}"
+  # Path based on cluster name (matches the catalog-orders repo directory layout)
+  path: "./${CLUSTER_NAME}"
   prune: true
   # Force mode: Continue applying resources even if some fail
   # This prevents a single error from blocking all other resources


### PR DESCRIPTION
## What

Make the Flux `catalog-orders` Kustomization key its name and path on the **cluster name** (`${CLUSTER_NAME}`) instead of the **kubectl context name** (`${CURRENT_CONTEXT}`), and remove the workaround in `cluster-config.sh` that aliased one to the other.

## Why

The `catalog-orders` repository has one directory per cluster (`openportal`, `rancher-desktop`, `kind-openportal`). Every other part of `cluster-config.sh` already keys on the cluster name: the `.env.<cluster>` file, the generated `app-config.<cluster>.local.yaml`, and the script's own success messages ("Watching path: ./${CLUSTER_NAME}"). Only `flux-catalog-orders.yaml` still used `${CURRENT_CONTEXT}`, kept working by a line that overrode `CURRENT_CONTEXT` with the cluster name and a comment calling it "backward compatibility".

That mismatch produced stale, broken Kustomizations on a cluster that had been configured under older context names: `catalog-orders-osp`, `catalog-orders-osp-production`, and `catalog-orders-osp-production-oidc`, each pointing at a `./osp*` path that does not exist in the repo, so all three sat permanently `Ready=False` with "kustomization path not found". Multiple contexts against one cluster (for example certificate auth and OIDC) also each created their own Kustomization instead of sharing one.

Keying on the cluster name fixes both: the path matches the repo layout, and contexts that share a cluster share a single Kustomization.

## Changes

- `scripts/manifests/config/flux-catalog-orders.yaml`: `${CURRENT_CONTEXT}` -> `${CLUSTER_NAME}` for the Kustomization name and path; comments updated to describe cluster-based naming.
- `scripts/cluster-config.sh`: drop `export CURRENT_CONTEXT="${CLUSTER_NAME}"`; `CLUSTER_NAME` is already exported for envsubst.

## Verification

- `CLUSTER_NAME=openportal envsubst < scripts/manifests/config/flux-catalog-orders.yaml` renders `name: catalog-orders-openportal` and `path: "./openportal"`.
- Applied to the openportal cluster: the new `catalog-orders-openportal` Kustomization now targets the correct `./openportal` directory; the three stale `catalog-orders-osp*` Kustomizations were removed.

## Follow-up (separate issue, not in this PR)

With the path corrected, the openportal orders surface a pre-existing ordering problem: `WhoAmIService` resources live in namespaces that are themselves created by `ManagedNamespace` resources in the same Kustomization, so the apply fails with "namespaces \"test\" not found" until the namespace exists. This is a structure issue in the `catalog-orders` repo (namespace-creating resources need to reconcile before namespaced resources) and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
