### PR TITLE
feat(rbac): declare cluster-admin bindings in manifests/users/admins.yaml

### DIFF
--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -441,6 +441,24 @@ configure_flux_catalog() {
 }
 
 
+# Apply cluster-admin bindings for OIDC users from the checked-in list
+apply_admin_bindings() {
+    echo -e "${YELLOW}Applying cluster-admin bindings (manifests/users/admins.yaml)...${NC}"
+
+    ADMINS_MANIFEST="$(cd "$(dirname "$0")" && pwd)/manifests/users/admins.yaml"
+
+    if [ ! -f "$ADMINS_MANIFEST" ]; then
+        echo -e "${YELLOW}⚠ No admins manifest found at $ADMINS_MANIFEST, skipping${NC}"
+        return
+    fi
+
+    kubectl apply -f "$ADMINS_MANIFEST"
+
+    echo -e "${GREEN}✓ Admin bindings applied${NC}"
+    echo "  Manage the list via PR on manifests/users/admins.yaml"
+    echo "  (rbac-add-admin.sh remains for one-off use — add its bindings to the file afterwards)"
+}
+
 # Create service account with persistent token
 # Arguments:
 #   $1 - Service account name (e.g., "backstage", "github-actions")
@@ -636,6 +654,7 @@ main() {
     install_environment_configs  # Install platform-wide configs
     create_service_account_with_token "backstage" "Persistent token for Backstage - shared by team"
     create_service_account_with_token "gha-app-portal-deploy" "GitHub Actions deployment for app-portal"
+    apply_admin_bindings  # Cluster-admin bindings from manifests/users/admins.yaml
     print_summary
     run_cluster_config  # Run configuration if environment file exists
 }

--- a/scripts/manifests/users/admins.yaml
+++ b/scripts/manifests/users/admins.yaml
@@ -1,0 +1,100 @@
+---
+# Cluster admins (OIDC users) — source of truth for explicit-admin bindings.
+#
+# This file lists every user with a cluster-admin ClusterRoleBinding on the
+# openportal cluster. Add/remove users here via PR, then apply with:
+#   kubectl apply -f scripts/manifests/users/admins.yaml
+# (also applied by scripts/cluster-setup.sh)
+#
+# For one-off/interactive use, scripts/users/rbac-add-admin.sh still works —
+# but every binding it creates should be added here afterwards, otherwise it
+# only lives in the cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-fboehm-ext
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for fboehm.ext@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:fboehm.ext@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-mbrueckner
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for mbrueckner@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:mbrueckner@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-mstingl
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for mstingl@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:mstingl@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-sftoma
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for sftoma@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:sftoma@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-primann
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for primann@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:primann@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## What

Adds `scripts/manifests/users/admins.yaml` declaring all five explicit-admin ClusterRoleBindings (`oidc:` users → `cluster-admin`), and an `apply_admin_bindings` step in `cluster-setup.sh` that applies it.

## Why

The admin bindings existed only in the cluster: `rbac-add-admin.sh` applies a template but persists nothing, and two bindings (`admin-sftoma`, `admin-primann`, added 2026-07-06) were applied ad-hoc without even that. With this file the admin list is reviewable via PR and survives a cluster rebuild.

## Notes

- Content matches the live cluster 1:1 (verified with `kubectl apply --dry-run=server` against openportal); labels stay compatible with `rbac-list-custom.sh`.
- `rbac-add-admin.sh` remains for interactive use — the file header asks to backfill this list afterwards.
- The stale `oidc-cluster-admin-group` binding (Auth0 role id, ineffective — no `oidc-groups-claim` on the apiserver) is intentionally NOT included; it can be deleted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
