### PR TITLE
feat(rbac): add jmarkert@cloudpunks.de as cluster admin

### DIFF
--- a/scripts/manifests/users/admins.yaml
+++ b/scripts/manifests/users/admins.yaml
@@ -84,6 +84,24 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: admin-jmarkert
+  labels:
+    rbac.openportal.dev/type: explicit-admin
+    rbac.openportal.dev/managed-by: rbac-add-admin
+  annotations:
+    rbac.openportal.dev/description: "Cluster admin access for jmarkert@cloudpunks.de"
+subjects:
+- kind: User
+  name: "oidc:jmarkert@cloudpunks.de"
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: admin-primann
   labels:
     rbac.openportal.dev/type: explicit-admin


### PR DESCRIPTION
Adds `admin-jmarkert` to `scripts/manifests/users/admins.yaml` (→ `cluster-admin` for `oidc:jmarkert@cloudpunks.de`), following the pattern from #138. Validated with `kubectl apply --dry-run=server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)