### PR TITLE
chore: remove agent-sync plugin from workspace settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "enabledPlugins": {
-    "agent-sync@ai-plugins-internal": true,
     "workspace@ai-plugins-internal": true,
     "knowledge@ai-plugins-internal": true,
     "craft@ai-plugins-internal": true


### PR DESCRIPTION
Removes the `agent-sync` plugin from the workspace's `enabledPlugins`.

It is no longer used here, so the setting no longer reflects how the workspace is actually run. Reverts the enablement from #122; the other plugins are untouched.

Config-only change — no effect on the repo's contents or on anyone not using the plugin.
