### PR TITLE
chore(security): add a pre-commit secret leak gate + CI backstop

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,16 @@
+# Secret-scan config for the leak-scan gate. Extends the upstream default rules,
+# and allowlists a few files that intentionally contain ILLUSTRATIVE example
+# secrets (documentation walkthroughs + an examples/ manifest), confirmed not
+# live. Real secrets anywhere else are still caught.
+title = "open-service-portal secret-scan"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Illustrative example secrets in docs/ and examples/ (verified not live)."
+paths = [
+  '''(^|/)docs/cluster-auth-implementation-summary\.md$''',
+  '''(^|/)docs/cluster-auth/certificate-authentication-explained\.md$''',
+  '''(^|/)examples/crossplane-rancher-examples/postgres-secret\.yaml$''',
+]

--- a/.git-deny-patterns.example
+++ b/.git-deny-patterns.example
@@ -1,0 +1,15 @@
+# Project-specific deny patterns for the pre-commit secret/internal-ref guard.
+#
+# ⚠️ NEVER COMMIT the filled-in `.git-deny-patterns` — it lists the internal names you are
+#    hiding, so committing it would publish exactly what you want to keep out. It is gitignored.
+#    Only THIS .example (placeholders, no real names) is shared. For a team, keep the real list
+#    in a private/synced folder and point the hook at it: export GIT_DENY_PATTERNS=/path/to/list
+#
+# Copy to `.git-deny-patterns` (bootstrap.sh does this) and add one extended-regex per line.
+# The guard blocks a commit if a staged added line matches any of these.
+# Use for things the built-in secret patterns don't cover — internal names, hosts, clients.
+#
+# Examples (uncomment + adapt):
+# AcmeCorp
+# internal\.example\.com
+# (staging|prod)-secret-host

--- a/.github/workflows/leak-scan.yml
+++ b/.github/workflows/leak-scan.yml
@@ -1,0 +1,32 @@
+# Secret leak scan — the always-on net that does not depend on a local hook being installed.
+# Kept as its own workflow (separate from other gates) so a security failure is never
+# entangled with, or masked by, an unrelated check.
+name: leak-scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  betterleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan git history + tree for secrets (betterleaks)
+        # The container runs as a different uid than the mounted checkout, so git would
+        # refuse it as "dubious ownership". Inject safe.directory via GIT_CONFIG_* env
+        # (no shell / entrypoint override needed — the image entrypoint is `betterleaks`).
+        run: >
+          docker run --rm
+          -e GIT_CONFIG_COUNT=1
+          -e GIT_CONFIG_KEY_0=safe.directory
+          -e GIT_CONFIG_VALUE_0=/repo
+          -v "${{ github.workspace }}:/repo"
+          ghcr.io/betterleaks/betterleaks:v1.6.1
+          git /repo --redact --exit-code 1

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ debug/
 
 # Local-only Claude Code safety hooks (personal allowlist, not for the public repo)
 .claude/hooks/
+
+# real denylist = the internal names you hide; never commit it (only .example is shared)
+.git-deny-patterns

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Pre-commit secret / internal-ref guard. Scans STAGED changes; blocks the commit on a match.
+# Bypass (rarely, deliberately): git commit --no-verify
+#
+# Two concerns, two mechanisms — deliberately not one hand-maintained regex list:
+#   1. GENERIC provider secrets  -> betterleaks (maintained upstream ruleset). We do NOT
+#      hand-maintain token regexes: a hand-copied subset silently rots (e.g. it misses
+#      GitHub's 2021 `ghp_` format change), and pinning the betterleaks version pins the
+#      patterns. betterleaks = the maintained successor to gitleaks (which went
+#      feature-complete / security-patches-only in Feb 2026); install: brew install betterleaks.
+#   2. PROJECT internal/stealth names -> the `.git-deny-patterns` denylist (zero-dep grep).
+#      No upstream scanner can ever know your internal names, so THIS list stays local and
+#      hand-maintained. One extended-regex per line; lines starting with # are ignored.
+#
+# If betterleaks is not installed, generic-secret scanning is skipped with a LOUD warning
+# (not a silent pass) — the CI leak-scan is the always-on net, and blocking every commit on a
+# missing optional tool would just get the hook disabled. The denylist always runs (zero-dep).
+#
+# Install: copy to .git/hooks/pre-commit (chmod +x). bootstrap.sh does this for you.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# --deny-only: skip the betterleaks generic-secret scan, check the project denylist only
+# (e.g. when betterleaks already runs as a separate lefthook/CI step).
+DENY_ONLY=0
+[ "${1:-}" = "--deny-only" ] && DENY_ONLY=1
+
+hit=0
+
+# --- 1. generic provider secrets via betterleaks (maintained ruleset) ---
+if [ "$DENY_ONLY" != 1 ]; then
+  if command -v betterleaks >/dev/null 2>&1; then
+    if ! betterleaks git --staged --redact --exit-code 1 >/dev/null 2>&1; then
+      echo "✗ pre-commit: betterleaks found a secret in the staged changes:"
+      betterleaks git --staged --redact 2>&1 \
+        | grep -iE 'finding|secret|rule|file:|line:|commit:' | head -12 | sed 's/^/      /'
+      hit=1
+    fi
+  else
+    echo "⚠ pre-commit: betterleaks is not installed — generic-secret scanning is OFF for this commit."
+    echo "  (The CI leak-scan still catches it; install locally for pre-push safety:)"
+    echo "    brew install betterleaks     # github.com/betterleaks/betterleaks"
+  fi
+fi
+
+# --- 2. project internal/stealth denylist (zero-dep, always) ---
+EXTRA=()
+load_deny() {
+  [ -f "$1" ] || return 0
+  while IFS= read -r line; do
+    [ -n "$line" ] && [ "${line#\#}" = "$line" ] && EXTRA+=("$line")
+  done < "$1"
+}
+load_deny "$ROOT/.git-deny-patterns"
+[ -n "${GIT_DENY_PATTERNS:-}" ] && load_deny "$GIT_DENY_PATTERNS"
+
+if [ "${#EXTRA[@]}" -gt 0 ]; then
+  # staged added lines (exclude this hook + the denylist so the scanner doesn't flag its own patterns)
+  staged="$(git diff --cached --no-color -U0 --diff-filter=ACM -- . ':(exclude)*pre-commit' ':(exclude)*.git-deny-patterns*' \
+            | grep -E '^\+' | grep -vE '^\+\+\+' || true)"
+  if [ -n "$staged" ]; then
+    for re in "${EXTRA[@]}"; do
+      [ -z "$re" ] && continue
+      if printf '%s\n' "$staged" | grep -niE "$re" >/dev/null 2>&1; then
+        echo "✗ pre-commit: internal/stealth ref  /$re/"
+        printf '%s\n' "$staged" | grep -niE "$re" | head -3 | sed 's/^/      /'
+        hit=1
+      fi
+    done
+  fi
+fi
+
+if [ "$hit" -ne 0 ]; then
+  echo ""
+  echo "  Commit blocked. Remove it, or bypass deliberately: git commit --no-verify"
+  exit 1
+fi
+exit 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,16 @@
+# lefthook.yml — pre-commit secret / internal-ref gate (primary path, battle-tested).
+#
+# Setup once per machine:  brew install lefthook betterleaks && lefthook install
+# Bypass deliberately:     git commit --no-verify     (or LEFTHOOK=0 git commit …)
+#
+# If lefthook/betterleaks are not installed, the fallback hooks/pre-commit covers it
+# (it calls betterleaks directly if present, and always runs the zero-dep internal-ref denylist) — bootstrap.sh installs whichever is available.
+pre-commit:
+  parallel: true
+  commands:
+    secrets:
+      # betterleaks scans staged changes for tokens/keys/high-entropy secrets (maintained ruleset)
+      run: betterleaks git --staged --redact --exit-code 1
+    internal-refs:
+      # project-internal names from the gitignored .git-deny-patterns (+ $GIT_DENY_PATTERNS)
+      run: bash hooks/pre-commit --deny-only


### PR DESCRIPTION
Adds a two-layer secret-leak gate so a credential or an internal name can't be committed unnoticed.

## Layers

- **Local pre-commit hook** (`hooks/pre-commit` + `lefthook.yml`) — fast, blocks the commit before it happens. Catches generic secrets via [betterleaks](https://github.com/betterleaks/betterleaks) (if installed) and project-internal names via the gitignored `.git-deny-patterns` denylist. Only `.git-deny-patterns.example` (placeholders) is committed — the filled-in list names exactly what it hides, so it is never committed.
- **CI net** (`.github/workflows/leak-scan.yml`) — the always-on layer that does not depend on a local hook being installed. betterleaks scans the tree + history on every push/PR. Kept as its own workflow so a security failure is never entangled with an unrelated gate.

## Degradation

If betterleaks isn't installed locally, the hook **warns loudly** (does not silently pass) and does **not** block on the missing tool alone — CI is the always-on net, and blocking every commit on an optional tool would just get the hook bypassed.

## Activation (per clone)

`cp hooks/pre-commit .git/hooks/pre-commit` (or `lefthook install` if using lefthook). The committed files travel; the active hook is local.

## Notes

- `.github/` is force-added past the repo's broad `.github/` ignore, consistent with the already-tracked `sync-labels.yml`.
- The CI workflow injects git `safe.directory` so the container-run scan doesn't trip on "dubious ownership".