### PR TITLE
chore: switch the enabled agent-channel plugin to cockpit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "enabledPlugins": {
-    "agent-sync@ai-plugins-internal": true,
+    "cockpit@ai-plugins-internal": true,
     "workspace@ai-plugins-internal": true,
     "knowledge@ai-plugins-internal": true,
     "craft@ai-plugins-internal": true


### PR DESCRIPTION
Replaces `agent-sync@ai-plugins-internal` with `cockpit@ai-plugins-internal` in `.claude/settings.json`.

The agent-sync plugin is retired and cockpit is its successor, so the current setting no longer reflects how this workspace is actually run.

Same scope as #143, which removes the stale entry without replacing it — this supersedes that PR by also enabling the successor. The other plugins are untouched.

Config-only change: no effect on the repo's contents, and none on anyone who does not use the plugin.